### PR TITLE
Integrate highlight playback into GUI

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -4,6 +4,7 @@ import os
 import tkinter as tk
 from tkinter import filedialog, messagebox
 from validator import validate_soundvault_structure
+from sample_highlight import play_file_highlight
 
 # Import the indexer API
 from music_indexer_api import run_full_indexer
@@ -54,6 +55,7 @@ class SoundVaultImporterApp(tk.Tk):
         # ─── Tools Menu ────────────────────────────────────────────────
         tools_menu = tk.Menu(menubar, tearoff=False)
         tools_menu.add_command(label="Regenerate Playlists", command=self.regenerate_playlists)
+        tools_menu.add_command(label="Sample Song Highlight", command=self.sample_song_highlight)
         menubar.add_cascade(label="Tools", menu=tools_menu)
 
         # A main text area for logging
@@ -158,6 +160,25 @@ class SoundVaultImporterApp(tk.Tk):
         save_last_path(chosen)
         messagebox.showinfo("Regenerate Playlists", f"[stub] Would regenerate playlists in:\n{chosen}")
         self._log(f"[stub] Regenerate Playlists → {chosen}")
+
+    def sample_song_highlight(self):
+        """Ask the user for an audio file and play its highlight."""
+        initial = load_last_path()
+        path = filedialog.askopenfilename(
+            title="Select Audio File",
+            initialdir=initial,
+            filetypes=[("Audio Files", "*.mp3 *.wav *.flac *.ogg"), ("All files", "*")],
+        )
+        if not path:
+            return
+
+        save_last_path(os.path.dirname(path))
+        try:
+            start_sec = play_file_highlight(path)
+            self._log(f"Played highlight of '{os.path.basename(path)}' starting at {start_sec:.2f}s")
+        except Exception as e:
+            messagebox.showerror("Playback failed", str(e))
+            self._log(f"✘ Playback failed for {path}: {e}")
 
     def _log(self, msg):
         self.output.configure(state="normal")

--- a/sample_highlight.py
+++ b/sample_highlight.py
@@ -1,0 +1,80 @@
+"""
+sample_highlight.py
+
+Play the loudest 30-second segment of an audio file.
+
+Usage:
+    python sample_highlight.py path/to/song.mp3
+
+Requires ``pydub`` and ``simpleaudio`` packages.
+"""
+
+import sys
+from pydub import AudioSegment
+import simpleaudio as sa
+
+WINDOW_MS = 30_000  # 30 seconds
+STEP_MS = 1_000     # slide window every second
+
+
+def find_loudest_segment(audio: AudioSegment, window_ms: int = WINDOW_MS, step_ms: int = STEP_MS) -> int:
+    """Return the start time (ms) of the loudest window of the given audio."""
+    if len(audio) <= window_ms:
+        return 0
+
+    best_start = 0
+    best_rms = -1
+    for start in range(0, len(audio) - window_ms + 1, step_ms):
+        seg = audio[start:start + window_ms]
+        if seg.rms > best_rms:
+            best_rms = seg.rms
+            best_start = start
+    return best_start
+
+
+def play_segment(segment: AudioSegment) -> None:
+    """Play the given audio segment and wait until it finishes."""
+    playback = sa.play_buffer(
+        segment.raw_data,
+        num_channels=segment.channels,
+        bytes_per_sample=segment.sample_width,
+        sample_rate=segment.frame_rate,
+    )
+    playback.wait_done()
+
+
+def play_file_highlight(path: str) -> float:
+    """Play the loudest 30-second highlight of the given audio file.
+
+    Returns the start time of the highlight in seconds."""
+    try:
+        audio = AudioSegment.from_file(path)
+    except Exception as exc:
+        raise RuntimeError(f"Could not open '{path}': {exc}") from exc
+
+    start_ms = find_loudest_segment(audio)
+    highlight = audio[start_ms:start_ms + WINDOW_MS]
+    play_segment(highlight)
+    return start_ms / 1000
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: python sample_highlight.py <audio_file>")
+        return
+    path = sys.argv[1]
+
+    try:
+        audio = AudioSegment.from_file(path)
+    except Exception as e:
+        print(f"Could not open '{path}': {e}")
+        return
+
+    start_ms = find_loudest_segment(audio)
+    highlight = audio[start_ms:start_ms + WINDOW_MS]
+    print(f"Playing highlight starting at {start_ms / 1000:.2f} s")
+    play_segment(highlight)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expose a `play_file_highlight` helper in `sample_highlight.py`
- add a new Tools menu item in the GUI to play the loudest 30‑second highlight of any audio file

## Testing
- `python -m py_compile main_gui.py sample_highlight.py`

------
https://chatgpt.com/codex/tasks/task_e_6842fdc299f88320b41550666631de07