### PR TITLE
Add tag fix logging & GUI filters

### DIFF
--- a/log_manager.py
+++ b/log_manager.py
@@ -1,0 +1,45 @@
+import json
+import os
+
+
+def get_log_path(library_root):
+    """Return absolute path to the tagger log for ``library_root``."""
+    return os.path.join(library_root, "docs", "tagger_log.json")
+
+
+def load_log(library_root):
+    """Load the tagger log for ``library_root``. Return empty dict if missing."""
+    path = get_log_path(library_root)
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except Exception:
+        return {}
+
+
+def prune_missing_entries(log_dict, library_root):
+    """Remove log entries for files that no longer exist."""
+    removed = []
+    for rel in list(log_dict.keys()):
+        abs_path = os.path.join(library_root, rel)
+        if not os.path.exists(abs_path):
+            removed.append(rel)
+            del log_dict[rel]
+    return removed
+
+
+def save_log(log_dict, library_root):
+    """Write ``log_dict`` back to disk for ``library_root``."""
+    path = get_log_path(library_root)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(log_dict, fh, indent=2)
+
+
+def reset_log(library_root):
+    """Delete the tagger log for ``library_root``."""
+    path = get_log_path(library_root)
+    if os.path.exists(path):
+        os.remove(path)

--- a/tag_fixer.py
+++ b/tag_fixer.py
@@ -3,6 +3,9 @@ import sys
 import argparse
 import acoustid
 from mutagen import File as MutagenFile
+from typing import Iterable, Callable, List, Tuple, Dict
+
+import log_manager
 
 # ─── Configuration ────────────────────────────────────────────────────────
 ACOUSTID_API_KEY       = "eBOqCZhyAx"
@@ -99,22 +102,31 @@ def prompt_user_about_tags(f, old_artist, old_title, new_tags):
     return (resp == "y")
 
 # ─── Main Tag-Fixing Logic ────────────────────────────────────────────────
-def collect_tag_proposals(target, log_callback=None):
-    """Walk files under ``target`` and return tagging proposals."""
+def collect_tag_proposals(
+    files: Iterable[str],
+    log_callback: Callable[[str], None] | None = None,
+    progress_callback: Callable[[int], None] | None = None,
+) -> Tuple[List[Dict], List[Dict]]:
+    """Return (diff_proposals, no_diff_files) for the given ``files``."""
     if log_callback is None:
-        def log_callback(msg):
+        def log_callback(msg: str):
             print(msg)
 
     if not ACOUSTID_API_KEY:
         raise RuntimeError("ACOUSTID_API_KEY not configured")
 
-    proposals = []
-    for f in find_files(target):
+    diff: List[Dict] = []
+    no_diff: List[Dict] = []
+    for idx, f in enumerate(files, start=1):
         if is_remix(f):
+            if progress_callback:
+                progress_callback(idx)
             continue
 
         log_callback(f"Fingerprinting {f}")
         result = query_acoustid(f, log_callback)
+        if progress_callback:
+            progress_callback(idx)
         if not result:
             continue
 
@@ -126,31 +138,67 @@ def collect_tag_proposals(target, log_callback=None):
         old_artist = (audio.tags.get("artist") or [None])[0] if audio and audio.tags else None
         old_title = (audio.tags.get("title") or [None])[0] if audio and audio.tags else None
 
-        proposals.append({
+        entry = {
             "file": f,
             "old_artist": old_artist,
             "old_title": old_title,
             "new_artist": result["artist"],
             "new_title": result["title"],
             "score": score,
-        })
+        }
 
-    return proposals
+        if old_artist == entry["new_artist"] and old_title == entry["new_title"]:
+            no_diff.append(entry)
+        else:
+            diff.append(entry)
+
+    return diff, no_diff
 
 
-def apply_tag_proposals(proposals, log_callback=None):
-    """Write the tags for each proposal and return the count updated."""
+def apply_tag_proposals(
+    selected: Iterable[Dict],
+    diff_proposals: Iterable[Dict],
+    no_diff_files: Iterable[Dict],
+    library_root: str,
+    log_callback: Callable[[str], None] | None = None,
+) -> int:
+    """Apply ``selected`` proposals and log all scan results."""
     if log_callback is None:
-        def log_callback(msg):
+        def log_callback(msg: str):
             print(msg)
 
+    selected_paths = {p["file"] for p in selected}
+
     updated = 0
-    for p in proposals:
+    for p in selected:
         path = p["file"]
         tags = {"artist": p["new_artist"], "title": p["new_title"]}
         if update_tags(path, tags, log_callback):
             updated += 1
 
+    # ─── Update log only after successful writes ──────────────────────────
+    log_data = log_manager.load_log(library_root)
+
+    def record(entry: Dict, status: str):
+        rel = os.path.relpath(entry["file"], library_root)
+        log_data[rel] = {
+            "status": status,
+            "old_artist": entry["old_artist"],
+            "old_title": entry["old_title"],
+            "new_artist": entry["new_artist"],
+            "new_title": entry["new_title"],
+        }
+
+    for p in diff_proposals:
+        if p["file"] in selected_paths:
+            record(p, "applied")
+        else:
+            record(p, "skipped")
+
+    for p in no_diff_files:
+        record(p, "no_diff")
+
+    log_manager.save_log(log_data, library_root)
     return updated
 
 
@@ -165,20 +213,21 @@ def fix_tags(target, log_callback=None, interactive=False):
         log_callback("No audio files found.")
         return {"processed": 0, "updated": 0}
 
-    proposals = collect_tag_proposals(target, log_callback)
+    diff_props, no_diff = collect_tag_proposals(files, log_callback)
+    selected = diff_props
 
     if interactive:
-        filtered = []
-        for p in proposals:
+        selected = []
+        for p in diff_props:
             apply_change = prompt_user_about_tags(
                 p["file"], p["old_artist"], p["old_title"],
                 {"artist": p["new_artist"], "title": p["new_title"]}
             )
             if apply_change:
-                filtered.append(p)
-        proposals = filtered
+                selected.append(p)
 
-    updated = apply_tag_proposals(proposals, log_callback)
+    root_path = target if os.path.isdir(target) else os.path.dirname(target)
+    updated = apply_tag_proposals(selected, diff_props, no_diff, root_path, log_callback)
 
     return {"processed": len(files), "updated": updated}
 


### PR DESCRIPTION
## Summary
- add `log_manager` module for per-library JSON logging
- log tag fixer actions and track missing/ignored files
- integrate log filtering and cleanup into GUI
- allow resetting the log
- update tag fixer core logic to use new logging and filtering

## Testing
- `python -m py_compile main_gui.py tag_fixer.py log_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_684453328b208320add21fccb273f9b3