### PR TITLE
Show old and suggested genres in dialog

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -417,8 +417,8 @@ class SoundVaultImporterApp(tk.Tk):
             "New Title",
             "Old Album",
             "New Album",
-            "Genres",
-            "Suggested Genre",
+            "Genres",            # existing embedded genres
+            "Suggested Genre",   # fetched from MusicBrainz
         )
 
         container = tk.Frame(dlg)
@@ -482,6 +482,7 @@ class SoundVaultImporterApp(tk.Tk):
                     p.new_title or "",
                     p.old_album or "",
                     p.new_album or "",
+                    ", ".join(p.old_genres or []),
                     ", ".join(p.new_genres or []),
                 ),
                 tags=(row_tag,),


### PR DESCRIPTION
## Summary
- show genres and suggested genres columns when reviewing tag proposals
- keep track of old and new genres in each TagProposal

## Testing
- `python -m py_compile main_gui.py tag_fixer.py`


------
https://chatgpt.com/codex/tasks/task_e_6844ae165c9c8320945d0a2ecee8a8a5