### PR TITLE
Improve genre merging in tag fixer

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -482,8 +482,8 @@ class SoundVaultImporterApp(tk.Tk):
                     p.new_title or "",
                     p.old_album or "",
                     p.new_album or "",
-                    ", ".join(p.old_genres or []),
-                    ", ".join(p.new_genres or []),
+                    ", ".join(p.old_genres),
+                    ", ".join(p.new_genres),
                 ),
                 tags=(row_tag,),
             )


### PR DESCRIPTION
## Summary
- keep old and new genre lists in `TagProposal`
- merge existing and new genres when applying proposals
- display genre lists properly in the GUI

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6844b4f266e88320b13d92048ae9978c