### PR TITLE
Expand proposal diff detection for albums and genres

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -469,7 +469,13 @@ class SoundVaultImporterApp(tk.Tk):
         all_rows = sorted(diff_proposals, key=lambda p: p.score, reverse=True) + list(no_diff_files)
         iid_to_prop = {}
         for p in all_rows:
-            row_tag = "perfect" if (p.old_artist == p.new_artist and p.old_title == p.new_title) else "changed"
+            all_same = (
+                p.old_artist == p.new_artist
+                and p.old_title == p.new_title
+                and p.old_album == p.new_album
+                and sorted(p.old_genres or []) == sorted(p.new_genres or [])
+            )
+            row_tag = "perfect" if all_same else "changed"
             iid = tv.insert(
                 "",
                 "end",

--- a/tag_fixer.py
+++ b/tag_fixer.py
@@ -215,7 +215,13 @@ def collect_tag_proposals(
             score=score,
         )
 
-        if old_artist == entry.new_artist and old_title == entry.new_title:
+        all_match = (
+            entry.old_artist == entry.new_artist
+            and entry.old_title == entry.new_title
+            and entry.old_album == entry.new_album
+            and sorted(entry.old_genres or []) == sorted(entry.new_genres or [])
+        )
+        if all_match:
             no_diff.append(entry)
         else:
             diff.append(entry)


### PR DESCRIPTION
## Summary
- expand diff detection in `collect_tag_proposals`
- highlight changed rows when album or genre differs

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6844b68d3ae88320b3c7092f0a01b47e