### PR TITLE
Use semicolons for genre lists

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -521,8 +521,8 @@ class SoundVaultImporterApp(tk.Tk):
                     p.new_title or "",
                     p.old_album or "",
                     p.new_album or "",
-                    ", ".join(p.old_genres),
-                    ", ".join(p.new_genres),
+                    "; ".join(p.old_genres or []),
+                    "; ".join(p.new_genres or []),
                 ),
                 tags=(row_tag,),
             )

--- a/tag_fixer.py
+++ b/tag_fixer.py
@@ -122,7 +122,7 @@ def update_tags(path: str, proposal: TagProposal, fields: List[str], log_callbac
                 merged.append(g)
                 seen.add(g)
         if merged != existing:
-            audio["genre"] = merged
+            audio["genre"] = ["; ".join(merged)]
             changed = True
     if changed:
         try:


### PR DESCRIPTION
## Summary
- display genres separated by semicolons
- write genres back to tags in the same format

## Testing
- `python -m py_compile main_gui.py tag_fixer.py`

------
https://chatgpt.com/codex/tasks/task_e_6844c254683c8320903ab2f8e48e6548