### PR TITLE
Show low-score tag matches in GUI

### DIFF
--- a/tag_fixer.py
+++ b/tag_fixer.py
@@ -151,6 +151,8 @@ def collect_tag_proposals(
     files: Iterable[str],
     log_callback: Callable[[str], None] | None = None,
     progress_callback: Callable[[int], None] | None = None,
+    *,
+    show_all: bool = False,
 ) -> Tuple[List[TagProposal], List[TagProposal]]:
     """Return (diff_proposals, no_diff_files) for the given ``files``."""
     if log_callback is None:
@@ -176,7 +178,7 @@ def collect_tag_proposals(
             continue
 
         score = result["score"]
-        if score < MIN_INTERACTIVE_SCORE:
+        if not show_all and score < MIN_INTERACTIVE_SCORE:
             continue
 
         mb_album = None


### PR DESCRIPTION
## Summary
- expose `show_all` flag in `collect_tag_proposals`
- highlight low-confidence rows red in the proposals table
- pass `show_all` from the GUI to the worker thread

## Testing
- `python -m py_compile tag_fixer.py main_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6844c6a204b08320a4f294957993b879