### PR TITLE
Fix Show All to include remixes

### DIFF
--- a/tag_fixer.py
+++ b/tag_fixer.py
@@ -165,7 +165,8 @@ def collect_tag_proposals(
     diff: List[TagProposal] = []
     no_diff: List[TagProposal] = []
     for idx, f in enumerate(files, start=1):
-        if is_remix(f):
+        # only skip remixes when NOT in Show All mode
+        if is_remix(f) and not show_all:
             if progress_callback:
                 progress_callback(idx)
             continue


### PR DESCRIPTION
## Summary
- respect `show_all` when filtering remix files

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844ca547fa08320be7eb4b25171a073