### PR TITLE
Fix Show-All filtering of applied files

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -335,7 +335,9 @@ class SoundVaultImporterApp(tk.Tk):
         if not proceed:
             return
 
-        if self.show_all or show_all:
+        show_all = show_all or self.show_all
+
+        if show_all:
             filtered = list(files)
             print(
                 f"[DEBUG] Show All mode: returning {len(filtered)} files (should match total)"
@@ -349,8 +351,8 @@ class SoundVaultImporterApp(tk.Tk):
                     f"[DEBUG] Checking {rel}, status={entry.get('status') if entry else 'none'}"
                 )
                 if entry:
-                    # always skip files already applied
-                    if entry.get("status") == "applied":
+                    # Skip already-applied only when NOT in Show All mode
+                    if entry.get("status") == "applied" and not show_all:
                         print("  → skipped: already applied")
                         continue
                     # optionally skip no-difference or skipped entries


### PR DESCRIPTION
## Summary
- preserve `show_all` flag when building filtered file list
- only skip already-applied entries when not in Show All mode

## Testing
- `python -m py_compile main_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_6844cf67c26c8320a15daad0800f6de8