### PR TITLE
Fix unmatched files visibility

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -574,7 +574,7 @@ class SoundVaultImporterApp(tk.Tk):
         tv = self._prop_tv
         tv.delete(*tv.get_children())
         for idx, rec in enumerate(records):
-            if rec.score is not None and rec.score < MIN_INTERACTIVE_SCORE:
+            if rec.score is None or rec.score < MIN_INTERACTIVE_SCORE or rec.status == 'unmatched':
                 tag = 'lowconf'
             elif (
                 rec.old_artist == rec.new_artist


### PR DESCRIPTION
## Summary
- handle lookup errors and empty results in tag fixer
- keep low-confidence matches in list
- highlight unmatched rows in the UI

## Testing
- `python -m py_compile *.py`
- `python tag_fixer.py --help` *(fails: ModuleNotFoundError: No module named 'acoustid')*

------
https://chatgpt.com/codex/tasks/task_e_6845f22fdbcc83208dbf45ccfcf3a23e