### PR TITLE
Refactor tag_fixer with plugin architecture

### DIFF
--- a/plugins/acoustid_plugin.py
+++ b/plugins/acoustid_plugin.py
@@ -1,0 +1,56 @@
+import acoustid
+import musicbrainzngs
+from itertools import islice
+
+from plugins.base import MetadataPlugin
+from tag_fixer import (
+    ACOUSTID_API_KEY,
+    ACOUSTID_APP_NAME,
+    ACOUSTID_APP_VERSION,
+)
+
+musicbrainzngs.set_useragent(
+    ACOUSTID_APP_NAME,
+    ACOUSTID_APP_VERSION,
+    "youremail@example.com",
+)
+
+class AcoustIDPlugin(MetadataPlugin):
+    def identify(self, file_path: str) -> dict:
+        try:
+            match_gen = acoustid.match(ACOUSTID_API_KEY, file_path)
+            peek = list(islice(match_gen, 5))
+            if not peek:
+                return {}
+
+            best_score, best_rid, best_title, best_artist = peek[0]
+        except acoustid.NoBackendError:
+            return {}
+        except acoustid.FingerprintGenerationError:
+            return {}
+        except acoustid.WebServiceError:
+            return {}
+
+        album = None
+        genres = []
+        if best_rid:
+            try:
+                rec = musicbrainzngs.get_recording_by_id(
+                    best_rid,
+                    includes=["releases", "tags"],
+                )["recording"]
+                rels = rec.get("releases", [])
+                if rels:
+                    album = rels[0].get("title")
+                mb_tags = rec.get("tag-list", [])
+                genres = [t["name"] for t in mb_tags if "name" in t]
+            except Exception:
+                pass
+
+        return {
+            "artist": best_artist,
+            "title": best_title,
+            "album": album,
+            "genres": genres,
+            "score": best_score,
+        }

--- a/plugins/base.py
+++ b/plugins/base.py
@@ -1,0 +1,10 @@
+class MetadataPlugin:
+    def identify(self, file_path: str) -> dict:
+        """Given a filepath, return a dict with any of:
+          - 'artist': str
+          - 'title': str
+          - 'album': str
+          - 'genres': list[str]
+          - 'score': float
+        or return {} or None if no data."""
+        raise NotImplementedError

--- a/plugins/test_plugin.py
+++ b/plugins/test_plugin.py
@@ -1,0 +1,11 @@
+import os
+from plugins.base import MetadataPlugin
+
+class TestPlugin(MetadataPlugin):
+    def identify(self, file_path: str) -> dict:
+        if os.path.basename(file_path).lower().startswith("dummy_"):
+            return {
+                "genres": ["TestGenre"],
+                "score": 1.0,
+            }
+        return {}


### PR DESCRIPTION
## Summary
- add plugin package and base interface
- move AcoustID/MusicBrainz logic into `AcoustIDPlugin`
- auto-discover plugins in `tag_fixer`
- remove old AcoustID code
- add simple test plugin

## Testing
- `python - <<'PY'
print('Smoke test skipped due to missing dependencies')
PY`

------
https://chatgpt.com/codex/tasks/task_e_684b6b178bfc832083bdb3d90aabcd46