### PR TITLE
Add centralized raw genre helper

### DIFF
--- a/controllers/normalize_controller.py
+++ b/controllers/normalize_controller.py
@@ -47,3 +47,17 @@ def save_mapping(folder: str, mapping: Dict[str, str]) -> str:
 def normalize_genres(genres: list[str], mapping: Dict[str, str]) -> list[str]:
     """Return list of genres normalized via mapping."""
     return [mapping.get(g, g) for g in genres]
+
+
+def get_raw_genres(records):
+    """
+    Given a list of FileRecord objects, return a sorted, deduplicated list of
+    all raw genre strings (from rec.old_genres and rec.new_genres).
+    """
+    raw_set = set()
+    for rec in records:
+        # include whatever fields you want—typically the pre-normalized tags:
+        raw_set.update(rec.old_genres)
+        # if you want newly suggested genres too:
+        raw_set.update(rec.new_genres)
+    return sorted(raw_set)

--- a/main_gui.py
+++ b/main_gui.py
@@ -27,7 +27,7 @@ from controllers.tagfix_controller import (
     gather_records,
     apply_proposals,
 )
-from controllers.normalize_controller import normalize_genres, PROMPT_TEMPLATE
+from controllers.normalize_controller import normalize_genres, PROMPT_TEMPLATE, get_raw_genres
 
 FilterFn = Callable[[FileRecord], bool]
 _cached_filters = None
@@ -653,13 +653,8 @@ class SoundVaultImporterApp(tk.Tk):
         self.text_raw = ScrolledText(win, width=50, height=15)
         self.text_raw.pack(fill="both", padx=10, pady=(0, 10))
 
-        # ── Raw Genre List Section ──
-        raw_set = set()
-        for rec in getattr(self, "all_records", []):
-            raw_set.update(rec.old_genres or [])
-            raw_set.update(rec.new_genres or [])
-        raw_list = sorted(raw_set)
-
+        # Populate via controller
+        raw_list = get_raw_genres(self.all_records)
         self.text_raw.configure(state="normal")
         self.text_raw.delete("1.0", "end")
         self.text_raw.insert("1.0", "\n".join(raw_list))


### PR DESCRIPTION
## Summary
- provide `get_raw_genres` helper in `normalize_controller`
- use helper from `main_gui` when filling the raw genre list

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684b912e9bb88320aa57533eecdfe61c