### PR TITLE
Add Llama assistant plugin

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -32,6 +32,7 @@ from controllers.normalize_controller import (
     load_mapping,
     scan_raw_genres,
 )
+from plugins.assistant_plugin import AssistantPlugin
 
 FilterFn = Callable[[FileRecord], bool]
 _cached_filters = None
@@ -98,6 +99,7 @@ class SoundVaultImporterApp(tk.Tk):
         self.show_all = False
         self.genre_mapping = {}
         self.mapping_path = ""
+        self.assistant_plugin = AssistantPlugin()
 
         # ─── Menu Bar ─────────────────────────────────────────────────────────
         menubar = tk.Menu(self)
@@ -804,8 +806,11 @@ class SoundVaultImporterApp(tk.Tk):
         self.chat_history.insert("end", f"User: {user_q}\n")
         self.chat_input.delete(0, "end")
 
-        # TODO: call your assistant_plugin.chat() here
-        bot_reply = "Assistant: (not yet implemented)\n"
+        try:
+            reply_text = self.assistant_plugin.chat(user_q)
+            bot_reply = f"Assistant: {reply_text}\n"
+        except Exception as e:
+            bot_reply = f"Assistant error: {e}\n"
 
         self.chat_history.insert("end", bot_reply)
         self.chat_history.configure(state="disabled")

--- a/plugins/assistant_plugin.py
+++ b/plugins/assistant_plugin.py
@@ -1,0 +1,26 @@
+import os
+from llama_cpp import Llama
+
+class AssistantPlugin:
+    """Simple chat assistant wrapper around a local Llama model."""
+
+    def __init__(self, model_path="models/llama3_8b.gguf", n_threads=6, n_ctx=2048):
+        """Load the Llama model from ``model_path`` or download it via Hugging Face."""
+        if os.path.isfile(model_path):
+            self.llm = Llama(model_path=model_path, n_threads=n_threads, n_ctx=n_ctx)
+        else:
+            self.llm = Llama.from_pretrained(
+                repo_id="QuantFactory/Meta-Llama-3-8B-Instruct-GGUF",
+                filename="*.gguf",
+                model_path=model_path,
+                n_threads=n_threads,
+            )
+
+    def chat(self, prompt: str, max_tokens: int = 256) -> str:
+        """Return the assistant's reply for ``prompt``."""
+        result = self.llm(
+            prompt,
+            max_tokens=max_tokens,
+            stop=["</s>"]
+        )
+        return result["choices"][0]["text"].strip()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pydub
 pyacoustid
 librosa  # optional, for BPM estimation
 requests
+llama-cpp-python
+huggingface-hub


### PR DESCRIPTION
## Summary
- create `AssistantPlugin` using llama-cpp-python
- load the model locally or auto-download via HF Hub
- integrate assistant into the GUI
- add dependencies to requirements

## Testing
- `python -m py_compile plugins/assistant_plugin.py main_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_684cc7fd748c83208072b9502ea37ae1