### PR TITLE
Enable dynamic GGUF model loading

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -173,6 +173,8 @@ class SoundVaultImporterApp(tk.Tk):
         self.chat_input.pack(side="left", fill="x", expand=True)
         send_btn = ttk.Button(entry_frame, text="Send", command=self._send_help_query)
         send_btn.pack(side="right", padx=(5,0))
+        reload_btn = ttk.Button(help_frame, text="Reload Models", command=self._reload_models)
+        reload_btn.pack(side="right", padx=10, pady=(0,10))
 
     def _load_genre_mapping(self):
         """Load genre mapping from ``self.mapping_path`` if possible."""
@@ -796,6 +798,18 @@ class SoundVaultImporterApp(tk.Tk):
             os.remove(db_path)
         messagebox.showinfo("Reset", "Tag-fix log cleared.")
         self._log(f"Reset tag-fix log for {folder}")
+
+    def _reload_models(self):
+        """
+        Re-initialize the AssistantPlugin so it re-scans models/ and reloads
+        any newly dropped GGUF files.
+        """
+        try:
+            self.assistant_plugin = AssistantPlugin()
+            messagebox.showinfo("Models Reloaded", "Model directory rescanned successfully.")
+        except Exception:
+            # Error dialogs are shown by AssistantPlugin already
+            pass
 
     def _send_help_query(self):
         user_q = self.chat_input.get().strip()

--- a/plugins/assistant_plugin.py
+++ b/plugins/assistant_plugin.py
@@ -1,20 +1,49 @@
-import os
+import glob, os
 from llama_cpp import Llama
+from tkinter import messagebox
 
 class AssistantPlugin:
-    """Simple chat assistant wrapper around a local Llama model."""
+    def __init__(self):
+        """
+        Auto-discovers any .gguf file in models/ or, if none, falls back
+        to downloading a default model. Shows an error if both fail.
+        """
+        models_dir = os.path.join(os.getcwd(), "models")
+        os.makedirs(models_dir, exist_ok=True)
 
-    def __init__(self, model_path="models/llama3_8b.gguf", n_threads=6, n_ctx=2048):
-        """Load the Llama model from ``model_path`` or download it via Hugging Face."""
-        if os.path.isfile(model_path):
-            self.llm = Llama(model_path=model_path, n_threads=n_threads, n_ctx=n_ctx)
-        else:
+        # 1) Look for any .gguf file
+        ggufs = glob.glob(os.path.join(models_dir, "*.gguf"))
+        if ggufs:
+            # Pick the newest file by modified time
+            ggufs.sort(key=os.path.getmtime, reverse=True)
+            model_path = ggufs[0]
+            try:
+                self.llm = Llama(model_path=model_path, n_threads=6, n_ctx=2048)
+                return
+            except Exception as e:
+                messagebox.showwarning(
+                    "Model Load Warning",
+                    f"Failed to load {os.path.basename(model_path)}:\n{e}\n\n"
+                    "Attempting automatic download instead."
+                )
+
+        # 2) Fallback: auto-download default via Hugging Face Hub
+        try:
             self.llm = Llama.from_pretrained(
                 repo_id="QuantFactory/Meta-Llama-3-8B-Instruct-GGUF",
                 filename="*.gguf",
-                model_path=model_path,
-                n_threads=n_threads,
+                local_dir=models_dir,
+                cache_dir=models_dir,
+                local_files_only=False,
+                n_threads=6,
+                n_ctx=2048
             )
+        except Exception as e:
+            messagebox.showerror(
+                "Assistant Initialization Failed",
+                f"Could not find or download any GGUF model:\n{e}"
+            )
+            raise
 
     def chat(self, prompt: str, max_tokens: int = 256) -> str:
         """Return the assistant's reply for ``prompt``."""


### PR DESCRIPTION
## Summary
- auto-discover GGUF models in `models/` and fall back to download
- add a **Reload Models** button in the Help tab
- implement `_reload_models` handler

## Testing
- `python -m py_compile plugins/assistant_plugin.py main_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_684cca0032388320b7f20ba2c0d3cc23