### PR TITLE
Improve Llama loading and error handling

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -815,18 +815,19 @@ class SoundVaultImporterApp(tk.Tk):
         user_q = self.chat_input.get().strip()
         if not user_q:
             return
-        # Echo user query
+
+        # echo the user's question
         self.chat_history.configure(state="normal")
-        self.chat_history.insert("end", f"User: {user_q}\n")
+        self.chat_history.insert("end", f"You: {user_q}\n")
         self.chat_input.delete(0, "end")
 
         try:
-            reply_text = self.assistant_plugin.chat(user_q)
-            bot_reply = f"Assistant: {reply_text}\n"
-        except Exception as e:
-            bot_reply = f"Assistant error: {e}\n"
+            reply = self.assistant_plugin.chat(user_q)
+        except Exception as err:
+            reply = f"[Error initializing or querying model]\n{err}"
 
-        self.chat_history.insert("end", bot_reply)
+        # display the assistant's response
+        self.chat_history.insert("end", f"Assistant: {reply}\n\n")
         self.chat_history.configure(state="disabled")
         self.chat_history.see("end")
 

--- a/plugins/assistant_plugin.py
+++ b/plugins/assistant_plugin.py
@@ -1,34 +1,17 @@
-import glob, os
+import os
 from llama_cpp import Llama
-from tkinter import messagebox
 
 class AssistantPlugin:
     def __init__(self):
         """
-        Auto-discovers any .gguf file in models/ or, if none, falls back
-        to downloading a default model. Shows an error if both fail.
+        Always attempt to load the model from Hugging Face (or local cache).
+        If it's already in models/, from_pretrained(local_files_only=True)
+        will pick it up without hitting the internet.
         """
         models_dir = os.path.join(os.getcwd(), "models")
         os.makedirs(models_dir, exist_ok=True)
-
-        # 1) Look for any .gguf file
-        ggufs = glob.glob(os.path.join(models_dir, "*.gguf"))
-        if ggufs:
-            # Pick the newest file by modified time
-            ggufs.sort(key=os.path.getmtime, reverse=True)
-            model_path = ggufs[0]
-            try:
-                self.llm = Llama(model_path=model_path, n_threads=6, n_ctx=2048)
-                return
-            except Exception as e:
-                messagebox.showwarning(
-                    "Model Load Warning",
-                    f"Failed to load {os.path.basename(model_path)}:\n{e}\n\n"
-                    "Attempting automatic download instead."
-                )
-
-        # 2) Fallback: auto-download default via Hugging Face Hub
         try:
+            # this will auto-download on first run, then load from models_dir
             self.llm = Llama.from_pretrained(
                 repo_id="QuantFactory/Meta-Llama-3-8B-Instruct-GGUF",
                 filename="*.gguf",
@@ -39,11 +22,8 @@ class AssistantPlugin:
                 n_ctx=2048
             )
         except Exception as e:
-            messagebox.showerror(
-                "Assistant Initialization Failed",
-                f"Could not find or download any GGUF model:\n{e}"
-            )
-            raise
+            # rethrow so the GUI can catch it
+            raise RuntimeError(f"Could not load LLM model: {e}") from e
 
     def chat(self, prompt: str, max_tokens: int = 256) -> str:
         """Return the assistant's reply for ``prompt``."""


### PR DESCRIPTION
## Summary
- simplify AssistantPlugin model loading with `Llama.from_pretrained()`
- surface model initialization errors in Help chat

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684cd175ac008320838c1b41f7f3ea64