### PR TITLE
Use local GGUF models for assistant

### DIFF
--- a/plugins/assistant_plugin.py
+++ b/plugins/assistant_plugin.py
@@ -1,29 +1,31 @@
-import os
+import glob, os
 from llama_cpp import Llama
 
 class AssistantPlugin:
     def __init__(self):
         """
-        Always attempt to load the model from Hugging Face (or local cache).
-        If it's already in models/, from_pretrained(local_files_only=True)
-        will pick it up without hitting the internet.
+        Load the first GGUF model found in ./models/, or raise an error.
         """
         models_dir = os.path.join(os.getcwd(), "models")
         os.makedirs(models_dir, exist_ok=True)
-        try:
-            # this will auto-download on first run, then load from models_dir
-            self.llm = Llama.from_pretrained(
-                repo_id="QuantFactory/Meta-Llama-3-8B-Instruct-GGUF",
-                filename="*.gguf",
-                local_dir=models_dir,
-                cache_dir=models_dir,
-                local_files_only=False,
-                n_threads=6,
-                n_ctx=2048
-            )
-        except Exception as e:
-            # rethrow so the GUI can catch it
-            raise RuntimeError(f"Could not load LLM model: {e}") from e
+
+        # 1) Discover any local .gguf file
+        gguf_paths = glob.glob(os.path.join(models_dir, "*.gguf"))
+        if gguf_paths:
+            # pick the newest by modification time
+            gguf_paths.sort(key=os.path.getmtime, reverse=True)
+            model_path = gguf_paths[0]
+            try:
+                self.llm = Llama(model_path=model_path, n_threads=6, n_ctx=2048)
+                return
+            except Exception as e:
+                raise RuntimeError(f"Failed to load model '{model_path}': {e}") from e
+
+        # 2) No local model found
+        raise RuntimeError(
+            "No GGUF model found in './models/'.\n"
+            "Please download or copy your .gguf file into the 'models' folder and restart."
+        )
 
     def chat(self, prompt: str, max_tokens: int = 256) -> str:
         """Return the assistant's reply for ``prompt``."""


### PR DESCRIPTION
## Summary
- rely solely on local `.gguf` models for the assistant plugin
- simplify imports

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cdbe9f18c8320be24bf00b2032ee4