### PR TITLE
Cleanup Python codebase

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,0 +1,1 @@
+# TODO: implement pybind11 bindings for llama.cpp here

--- a/bindings/llama_bindings.cpp
+++ b/bindings/llama_bindings.cpp
@@ -1,0 +1,1 @@
+// TODO: implement pybind11 bindings for llama.cpp here

--- a/plugins/assistant_plugin.py
+++ b/plugins/assistant_plugin.py
@@ -1,29 +1,6 @@
-import glob, os
-from ctransformers import LLM
-
 class AssistantPlugin:
     def __init__(self):
-        """
-        Load the first GGUF model found in ./models/
-        using ctransformers (bundled DLLs/no build).
-        """
-        models_dir = os.path.join(os.getcwd(), "models")
-        os.makedirs(models_dir, exist_ok=True)
-
-        # 1) Find any .gguf in models/
-        ggufs = glob.glob(os.path.join(models_dir, "*.gguf"))
-        if not ggufs:
-            raise RuntimeError(
-                "No GGUF model found in './models/'. "
-                "Please drop your .gguf file into the models folder."
-            )
-        ggufs.sort(key=os.path.getmtime, reverse=True)
-        model_path = ggufs[0]
-
-        # 2) Initialize ctransformers LLM
-        # Pass the path as the first argument instead of using the 'model' keyword
-        self.llm = LLM(model_path, model_type="llama", n_threads=6)
+        pass
 
     def chat(self, prompt: str) -> str:
-        """Send a prompt to the local model and return its response."""
-        return self.llm(prompt, max_tokens=256)
+        raise NotImplementedError("LLM integration not yet implemented")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,3 @@ pydub
 pyacoustid
 librosa  # optional, for BPM estimation
 requests
-huggingface-hub
-ctransformers>=0.2.27


### PR DESCRIPTION
## Summary
- stub out `AssistantPlugin`
- simplify `main_gui` and remove model reload
- drop LLM dependencies
- add placeholder C++ bindings directory

## Testing
- `python main_gui.py` *(fails: ModuleNotFoundError: No module named 'mutagen')*

------
https://chatgpt.com/codex/tasks/task_e_684ee3e51dc4832091b8cac1dea881d0