### PR TITLE
Fix sqlite DB creation and log callback bug

### DIFF
--- a/controllers/tagfix_controller.py
+++ b/controllers/tagfix_controller.py
@@ -29,6 +29,8 @@ def discover_files(folder: str) -> List[str]:
 
 def gather_records(folder: str, db_path: str, show_all: bool, progress_callback: Callable[[int], None] | None) -> List[FileRecord]:
     """Build FileRecord objects for ``folder``."""
+    db_folder = os.path.dirname(db_path)
+    os.makedirs(db_folder, exist_ok=True)
     conn = sqlite3.connect(db_path)
     records = build_file_records(
         folder,
@@ -46,6 +48,8 @@ def apply_proposals(selected: List[FileRecord], all_records: List[FileRecord], d
     """Apply tag proposals and update DB."""
     count = apply_tag_proposals(selected, fields=fields, log_callback=log_callback)
     selected_paths = {rec.path for rec in selected}
+    db_folder = os.path.dirname(db_path)
+    os.makedirs(db_folder, exist_ok=True)
     conn = sqlite3.connect(db_path)
     for rec in all_records:
         if rec.path in selected_paths:

--- a/fingerprint_generator.py
+++ b/fingerprint_generator.py
@@ -12,6 +12,8 @@ def compute_fingerprints(root_path: str, db_path: str, log_callback: Callable[[s
         def log_callback(msg: str) -> None:
             pass
 
+    db_folder = os.path.dirname(db_path)
+    os.makedirs(db_folder, exist_ok=True)
     conn = sqlite3.connect(db_path)
     conn.execute(
         """

--- a/main_gui.py
+++ b/main_gui.py
@@ -330,8 +330,10 @@ class SoundVaultImporterApp(tk.Tk):
                     self.after(0, lambda: messagebox.showinfo("Indexing Complete", f"Moved/renamed {summary.get('moved', 0)} files."))
                 self.after(0, lambda: self._log(f"✓ Run Indexer finished for {path}. Dry run: {dry_run}."))
             except Exception as e:
-                self.after(0, lambda: messagebox.showerror("Indexing failed", str(e)))
-                self.after(0, lambda: self._log(f"✘ Run Indexer failed for {path}: {e}"))
+                err = str(e)
+                msg = f"✘ Run Indexer failed for {path}: {err}"
+                self.after(0, lambda m=err: messagebox.showerror("Indexing failed", m))
+                self.after(0, lambda m=msg: self._log(m))
             finally:
                 self.after(0, dlg.destroy)
                 self.after(0, self.update_library_info)

--- a/music_indexer_api.py
+++ b/music_indexer_api.py
@@ -187,6 +187,8 @@ def compute_moves_and_tag_index(root_path, log_callback=None):
     SUPPORTED_EXTS = {".flac", ".m4a", ".aac", ".mp3", ".wav", ".ogg"}
 
     db_path = os.path.join(root_path, ".soundvault.db")
+    db_folder = os.path.dirname(db_path)
+    os.makedirs(db_folder, exist_ok=True)
     db = sqlite3.connect(db_path)
     db.execute(
         """

--- a/tag_fixer.py
+++ b/tag_fixer.py
@@ -15,6 +15,8 @@ import sqlite3
 # ─── Database Helpers ─────────────────────────────────────────────────────
 def init_db(path: str):
     """Create the SQLite database schema if needed."""
+    db_folder = os.path.dirname(path)
+    os.makedirs(db_folder, exist_ok=True)
     conn = sqlite3.connect(path)
     c = conn.cursor()
     c.execute(
@@ -305,6 +307,8 @@ def fix_tags(target, log_callback=None, interactive=False):
     )
     init_db(db_path)
 
+    db_folder = os.path.dirname(db_path)
+    os.makedirs(db_folder, exist_ok=True)
     db_conn = sqlite3.connect(db_path)
     records = build_file_records(
         target,
@@ -334,6 +338,8 @@ def fix_tags(target, log_callback=None, interactive=False):
         log_callback=log_callback,
     )
 
+    db_folder = os.path.dirname(db_path)
+    os.makedirs(db_folder, exist_ok=True)
     db_conn = sqlite3.connect(db_path)
     selected_set = {rec.path for rec in selected}
     for rec in records:


### PR DESCRIPTION
## Summary
- avoid closing over exception variable in indexing thread
- ensure db directories exist before connecting

## Testing
- `python -m py_compile main_gui.py music_indexer_api.py controllers/tagfix_controller.py fingerprint_generator.py tag_fixer.py`

------
https://chatgpt.com/codex/tasks/task_e_685356f4bd108320b50684b394ac5e8c