### PR TITLE
Fix indexer cleanup logic

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -329,11 +329,11 @@ class SoundVaultImporterApp(tk.Tk):
                 else:
                     self.after(0, lambda: messagebox.showinfo("Indexing Complete", f"Moved/renamed {summary.get('moved', 0)} files."))
                 self.after(0, lambda: self._log(f"✓ Run Indexer finished for {path}. Dry run: {dry_run}."))
-            except Exception as e:
-                err = str(e)
-                msg = f"✘ Run Indexer failed for {path}: {err}"
-                self.after(0, lambda m=err: messagebox.showerror("Indexing failed", m))
-                self.after(0, lambda m=msg: self._log(m))
+            except Exception:
+                import traceback
+                err_msg = traceback.format_exc().strip()
+                self.after(0, lambda m=err_msg: messagebox.showerror("Indexing failed", m))
+                self.after(0, lambda m=err_msg: self._log(f"✘ Run Indexer failed for {path}:\n{m}"))
             finally:
                 self.after(0, dlg.destroy)
                 self.after(0, self.update_library_info)

--- a/music_indexer_api.py
+++ b/music_indexer_api.py
@@ -657,13 +657,21 @@ def apply_indexer_moves(root_path, log_callback=None, progress_callback=None):
     os.makedirs(TRASH_ROOT, exist_ok=True)
 
     for dirpath, dirnames, filenames in os.walk(MUSIC_ROOT, topdown=False):
+        # 1) Don’t recurse into the Trash folder
+        dirnames[:] = [d for d in dirnames if d.lower() != "trash"]
+
         target_dirs = olddir_to_newdirs.get(dirpath, set())
 
         for fname in filenames:
             full = os.path.join(dirpath, fname)
             ext = os.path.splitext(fname)[1].lower()
 
-            # 6.1) If this was not an audio file (ext not in SUPPORTED_EXTS)
+            # 2) Never trash database files
+            if ext == ".db":
+                continue
+
+            # 3) Move any other non-audio leftovers into Trash or to the
+            #    appropriate album folder when possible
             if full not in moves and ext not in SUPPORTED_EXTS:
                 # 6.1.a) If it’s an image and all audio from this folder went to one album folder,
                 #       move the image into that album folder so the cover stays with that album.


### PR DESCRIPTION
## Summary
- avoid descending into Trash and ignore *.db files when cleaning leftovers
- capture traceback for indexer errors in GUI

## Testing
- `python -m py_compile music_indexer_api.py main_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_685360491c9483209324ab1a692cfdc0