### PR TITLE
Implement Not Sorted exclusion

### DIFF
--- a/fingerprint_generator.py
+++ b/fingerprint_generator.py
@@ -27,6 +27,9 @@ def compute_fingerprints(root_path: str, db_path: str, log_callback: Callable[[s
 
     audio_files = []
     for dirpath, _, files in os.walk(root_path):
+        rel_dir = os.path.relpath(dirpath, root_path)
+        if "Not Sorted" in rel_dir.split(os.sep):
+            continue
         for fname in files:
             ext = os.path.splitext(fname)[1].lower()
             if ext in SUPPORTED_EXTS:


### PR DESCRIPTION
## Summary
- allow user exclusion via `Not Sorted` folder
- skip anything inside `Not Sorted` during fingerprinting and indexing
- create helper button in the GUI to open the folder and show hint on dry runs

## Testing
- `python -m py_compile music_indexer_api.py main_gui.py fingerprint_generator.py`
- `pytest -k "test_plugin" -q` *(fails: ModuleNotFoundError: No module named 'pybind11_tests')*

------
https://chatgpt.com/codex/tasks/task_e_68605c39b2688320947f6730ff8cab23