### PR TITLE
Persist UI scale across sessions

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,22 @@
+import os
+import json
+
+CONFIG_PATH = os.path.expanduser("~/.soundvault_config.json")
+
+
+def load_config():
+    """Load configuration from ``CONFIG_PATH``.
+
+    Returns an empty dict if the file does not exist or can't be read.
+    """
+    try:
+        with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def save_config(cfg: dict) -> None:
+    """Write ``cfg`` to ``CONFIG_PATH`` as JSON."""
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)

--- a/main_gui.py
+++ b/main_gui.py
@@ -54,6 +54,7 @@ from controllers.normalize_controller import (
     scan_raw_genres,
 )
 from plugins.assistant_plugin import AssistantPlugin
+from config import load_config, save_config
 
 FilterFn = Callable[[FileRecord], bool]
 _cached_filters = None
@@ -111,9 +112,13 @@ class SoundVaultImporterApp(tk.Tk):
     def __init__(self):
         super().__init__()
         # Auto-detect and apply default DPI scaling
+        cfg = load_config()
         width, height = self.winfo_screenwidth(), self.winfo_screenheight()
-        self.current_scale = 1.5 if (width >= 1920 and height >= 1080) else 1.25
-        self.tk.call('tk', 'scaling', self.current_scale)
+        default_scale = cfg.get("ui_scale") or (
+            1.5 if (width >= 1920 and height >= 1080) else 1.25
+        )
+        self.current_scale = default_scale
+        self.tk.call("tk", "scaling", self.current_scale)
         self.title("SoundVault Importer")
         self.geometry("700x500")
 
@@ -262,10 +267,13 @@ class SoundVaultImporterApp(tk.Tk):
         """Rebuild UI under the new scaling factor."""
         try:
             scale = float(self.scale_var.get())
-            self.tk.call('tk', 'scaling', scale)
+            self.tk.call("tk", "scaling", scale)
             self.current_scale = scale
         except ValueError:
             return
+        cfg = load_config()
+        cfg["ui_scale"] = scale
+        save_config(cfg)
         for widget in self.winfo_children():
             widget.destroy()
         self.build_ui()


### PR DESCRIPTION
## Summary
- add config helper for saving simple JSON settings
- load saved UI scale at startup and remember changes

## Testing
- `python -m py_compile config.py main_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6860a30896908320a78552361edf78f1