### PR TITLE
Unify library selection for Indexer

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -228,23 +228,19 @@ class SoundVaultImporterApp(tk.Tk):
         self.indexer_tab = ttk.Frame(self.notebook)
         self.notebook.add(self.indexer_tab, text="Indexer")
 
-        ttk.Label(self.indexer_tab, text="Library Folder:").grid(row=0, column=0, sticky="w")
-        self.folder_entry = ttk.Entry(self.indexer_tab, width=40)
-        self.folder_entry.grid(row=0, column=1, padx=5, sticky="ew")
-        ttk.Button(self.indexer_tab, text="Browse...", command=self.browse_folder).grid(row=0, column=2)
-
+        # (Library path now selected via Choose Library… in the main toolbar)
         self.dry_run_var = tk.BooleanVar(value=True)
-        ttk.Checkbutton(self.indexer_tab, text="Dry Run", variable=self.dry_run_var).grid(row=1, column=0, columnspan=2, sticky="w")
+        ttk.Checkbutton(self.indexer_tab, text="Dry Run", variable=self.dry_run_var).grid(row=0, column=0, columnspan=2, sticky="w")
 
-        ttk.Button(self.indexer_tab, text="Start Indexer", command=self.run_indexer).grid(row=2, column=0, pady=10)
-        ttk.Button(self.indexer_tab, text="Open 'Not Sorted' Folder", command=self.open_not_sorted_folder).grid(row=2, column=1, pady=10)
+        ttk.Button(self.indexer_tab, text="Start Indexer", command=self.run_indexer).grid(row=1, column=0, pady=10)
+        ttk.Button(self.indexer_tab, text="Open 'Not Sorted' Folder", command=self.open_not_sorted_folder).grid(row=1, column=1, pady=10)
 
         self.pb = ttk.Progressbar(self.indexer_tab, length=300, mode="determinate")
-        self.pb.grid(row=3, column=0, columnspan=3, pady=5, sticky="ew")
+        self.pb.grid(row=2, column=0, columnspan=2, pady=5, sticky="ew")
         self.log = Text(self.indexer_tab, height=10)
-        self.log.grid(row=4, column=0, columnspan=3, sticky="nsew", pady=5)
-        self.indexer_tab.rowconfigure(4, weight=1)
-        self.indexer_tab.columnconfigure((0, 1, 2), weight=1)
+        self.log.grid(row=3, column=0, columnspan=2, sticky="nsew", pady=5)
+        self.indexer_tab.rowconfigure(3, weight=1)
+        self.indexer_tab.columnconfigure((0, 1), weight=1)
 
         # after your other tabs
         help_frame = ttk.Frame(self.notebook)
@@ -309,9 +305,6 @@ class SoundVaultImporterApp(tk.Tk):
         self.library_path_var.set(info["path"])
         self.mapping_path = os.path.join(self.library_path, ".genre_mapping.json")
         self._load_genre_mapping()
-        if hasattr(self, "folder_entry"):
-            self.folder_entry.delete(0, tk.END)
-            self.folder_entry.insert(0, info["path"])
         self.update_library_info()
 
     def update_library_info(self):
@@ -328,16 +321,6 @@ class SoundVaultImporterApp(tk.Tk):
             messagebox.showwarning("No Library", "Please select a library first.")
             return None
         return self.library_path
-
-    def browse_folder(self):
-        """Choose folder for the indexer tab."""
-        initial = load_last_path()
-        chosen = filedialog.askdirectory(title="Select SoundVault Root", initialdir=initial)
-        if not chosen:
-            return
-        save_last_path(chosen)
-        self.folder_entry.delete(0, tk.END)
-        self.folder_entry.insert(0, chosen)
 
     def validate_library(self):
         path = self.require_library()
@@ -397,9 +380,8 @@ class SoundVaultImporterApp(tk.Tk):
             self._log(f"✘ Import failed for {import_folder}: {e}")
 
     def run_indexer(self):
-        path = self.folder_entry.get().strip()
+        path = self.require_library()
         if not path:
-            messagebox.showwarning("No Folder", "Please choose a library folder.")
             return
 
         dry_run = self.dry_run_var.get()
@@ -464,9 +446,8 @@ class SoundVaultImporterApp(tk.Tk):
         threading.Thread(target=task, daemon=True).start()
 
     def open_not_sorted_folder(self):
-        path = self.folder_entry.get().strip()
+        path = self.require_library()
         if not path:
-            messagebox.showwarning("No Folder", "Please choose a library folder.")
             return
         not_sorted = os.path.join(path, "Not Sorted")
         os.makedirs(not_sorted, exist_ok=True)


### PR DESCRIPTION
## Summary
- simplify Indexer tab UI
- load chosen library path from the main "Choose Library" button for running the indexer
- remove redundant folder picker and helper

## Testing
- `python -m py_compile main_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_686131a710e48320b1bcefec2ad2bcfd