### PR TITLE
Add AcoustID connectivity check

### DIFF
--- a/plugins/acoustid_plugin.py
+++ b/plugins/acoustid_plugin.py
@@ -54,3 +54,14 @@ class AcoustIDPlugin(MetadataPlugin):
             "genres": genres,
             "score": best_score,
         }
+
+    @staticmethod
+    def check_connection() -> bool:
+        """Return True if AcoustID web service is reachable."""
+        try:
+            acoustid.match(ACOUSTID_API_KEY, b"")
+        except acoustid.WebServiceError:
+            return False
+        except Exception:
+            return False
+        return True

--- a/tag_fixer.py
+++ b/tag_fixer.py
@@ -176,6 +176,16 @@ def build_file_records(
 
     records: List[FileRecord] = []
 
+    for plugin in PLUGINS:
+        checker = getattr(plugin, "check_connection", None)
+        if callable(checker):
+            try:
+                if not checker():
+                    log_callback("⚠ Cannot reach AcoustID service \u2013 genre lookups will be skipped")
+            except Exception:
+                log_callback("⚠ Cannot reach AcoustID service \u2013 genre lookups will be skipped")
+            break
+
     existing_status = dict(db_conn.execute("SELECT path, status FROM files"))
 
     files = find_files(root)


### PR DESCRIPTION
## Summary
- add `check_connection` static method to `AcoustIDPlugin`
- warn users when AcoustID service cannot be reached

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pybind11_tests')*

------
https://chatgpt.com/codex/tasks/task_e_6861b38f57688320b24f51ea58ed74a6