### PR TITLE
Implement clustered playlist generation

### DIFF
--- a/clustered_playlists.py
+++ b/clustered_playlists.py
@@ -1,0 +1,70 @@
+import os
+import numpy as np
+import librosa
+from sklearn.cluster import KMeans
+from sklearn.preprocessing import StandardScaler
+import hdbscan
+from playlist_generator import DEFAULT_EXTS
+
+
+def extract_features(file_path: str) -> np.ndarray:
+    """Return a feature vector for the given audio file."""
+    y, sr = librosa.load(file_path, sr=None, mono=True)
+    mfcc = librosa.feature.mfcc(y=y, sr=sr, n_mfcc=13)
+    chroma = librosa.feature.chroma_stft(y=y, sr=sr)
+    tempo, _ = librosa.beat.beat_track(y=y, sr=sr)
+    vec = np.hstack([
+        np.mean(mfcc, axis=1),
+        np.std(mfcc, axis=1),
+        np.mean(chroma, axis=1),
+        [tempo],
+    ])
+    return vec.astype(np.float32)
+
+
+def cluster_tracks(feature_matrix: np.ndarray, method: str = "kmeans", **kwargs) -> np.ndarray:
+    """Cluster a matrix of feature vectors using KMeans or HDBSCAN."""
+    if method == "kmeans":
+        n_clusters = int(kwargs.get("n_clusters", 5))
+        km = KMeans(n_clusters=n_clusters)
+        labels = km.fit_predict(feature_matrix)
+    else:
+        min_cluster_size = int(kwargs.get("min_cluster_size", 5))
+        db = hdbscan.HDBSCAN(min_cluster_size=min_cluster_size)
+        labels = db.fit_predict(feature_matrix)
+    return labels
+
+
+def generate_clustered_playlists(tracks, root_path: str, method: str, params: dict, log_callback=None) -> None:
+    """Create clustered playlists for the given tracks."""
+    if log_callback is None:
+        log_callback = lambda msg: None
+
+    feats = []
+    for idx, path in enumerate(tracks, 1):
+        log_callback(f"\u2022 Extracting features {idx}/{len(tracks)}")
+        try:
+            feats.append(extract_features(path))
+        except Exception as e:
+            log_callback(f"! Failed features for {path}: {e}")
+            feats.append(np.zeros(27, dtype=np.float32))
+
+    X = np.vstack(feats)
+    X = StandardScaler().fit_transform(X)
+    labels = cluster_tracks(X, method, **params)
+
+    playlists_dir = os.path.join(root_path, "Playlists")
+    os.makedirs(playlists_dir, exist_ok=True)
+
+    for cluster_id in sorted(set(labels)):
+        if cluster_id < 0:
+            continue
+        playlist = [tracks[i] for i, lbl in enumerate(labels) if lbl == cluster_id]
+        outfile = os.path.join(playlists_dir, f"{method}_cluster_{cluster_id}.m3u")
+        try:
+            with open(outfile, "w", encoding="utf-8") as pf:
+                for p in playlist:
+                    pf.write(os.path.relpath(p, playlists_dir) + "\n")
+            log_callback(f"\u2192 Writing clustered playlist: {outfile}")
+        except Exception as e:
+            log_callback(f"\u2717 Failed to write {outfile}: {e}")

--- a/main_gui.py
+++ b/main_gui.py
@@ -54,6 +54,8 @@ from controllers.normalize_controller import (
     scan_raw_genres,
 )
 from plugins.assistant_plugin import AssistantPlugin
+from playlist_generator import DEFAULT_EXTS
+from clustered_playlists import generate_clustered_playlists
 from config import load_config, save_config
 
 FilterFn = Callable[[FileRecord], bool]
@@ -185,6 +187,16 @@ class SoundVaultImporterApp(tk.Tk):
         tools_menu.add_separator()
         tools_menu.add_command(label="Genre Normalizer", command=self._open_genre_normalizer)
         tools_menu.add_command(label="Reset Tag-Fix Log", command=self.reset_tagfix_log)
+        cluster_menu = tk.Menu(tools_menu, tearoff=False)
+        cluster_menu.add_command(
+            label="K-Means…",
+            command=lambda: self.cluster_playlists_dialog("kmeans"),
+        )
+        cluster_menu.add_command(
+            label="HDBSCAN…",
+            command=lambda: self.cluster_playlists_dialog("hdbscan"),
+        )
+        tools_menu.add_cascade(label="Clustered Playlists", menu=cluster_menu)
         menubar.add_cascade(label="Tools", menu=tools_menu)
 
         # ─── Library Info ───────────────────────────────────────────────────
@@ -526,6 +538,49 @@ class SoundVaultImporterApp(tk.Tk):
         )
         self._log(f"[stub] Regenerate Playlists → {path}")
         self.update_library_info()
+
+    def cluster_playlists_dialog(self, method: str):
+        dlg = tk.Toplevel(self)
+        dlg.title(f"Clustered Playlists – {method.title()}")
+        dlg.grab_set()
+        var = tk.StringVar(value="5")
+        label = (
+            "Number of clusters:" if method == "kmeans" else "Min cluster size:"
+        )
+        tk.Label(dlg, text=label).pack(padx=10, pady=(10, 0))
+        ttk.Entry(dlg, textvariable=var, width=10).pack(padx=10, pady=5)
+        ttk.Button(
+            dlg,
+            text="Generate",
+            command=lambda: self._start_cluster_playlists(method, var.get(), dlg),
+        ).pack(pady=(5, 10))
+
+    def _start_cluster_playlists(self, method: str, value: str, dlg):
+        dlg.destroy()
+        path = self.require_library()
+        if not path:
+            return
+        try:
+            num = int(value)
+        except ValueError:
+            messagebox.showerror("Invalid Value", f"{value} is not a valid number")
+            return
+        threading.Thread(
+            target=self._run_cluster_generation,
+            args=(path, method, num),
+            daemon=True,
+        ).start()
+
+    def _run_cluster_generation(self, path: str, method: str, num: int):
+        music_root = os.path.join(path, "Music") if os.path.isdir(os.path.join(path, "Music")) else path
+        tracks = []
+        for dirpath, _, files in os.walk(music_root):
+            for fname in files:
+                if os.path.splitext(fname)[1].lower() in DEFAULT_EXTS:
+                    tracks.append(os.path.join(dirpath, fname))
+        params = {"n_clusters": num} if method == "kmeans" else {"min_cluster_size": num}
+        generate_clustered_playlists(tracks, path, method, params, self._log)
+        self.after(0, lambda: messagebox.showinfo("Clustered Playlists", "Generation complete"))
 
     def _tagfix_filter_dialog(self):
         dlg = tk.Toplevel(self)


### PR DESCRIPTION
## Summary
- add clustered playlist module to create playlists via KMeans or HDBSCAN
- integrate new menu items in GUI to trigger playlist clustering
- run heavy playlist tasks on a thread to keep the UI responsive

## Testing
- `python -m py_compile main_gui.py clustered_playlists.py playlist_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_6861f8a3eac08320a4452909acad3302