### PR TITLE
Refactor interactive clustering UI

### DIFF
--- a/cluster_graph_panel.py
+++ b/cluster_graph_panel.py
@@ -1,0 +1,61 @@
+import os
+import numpy as np
+from tkinter import ttk
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+from matplotlib.figure import Figure
+from matplotlib.widgets import LassoSelector
+from matplotlib.path import Path
+
+from playlist_generator import write_playlist
+
+
+class ClusterGraphPanel(ttk.Frame):
+    """Interactive scatter plot for selecting clustered songs."""
+
+    def __init__(self, parent, tracks, features, cluster_func, cluster_params, library_path, log_callback):
+        super().__init__(parent)
+        self.tracks = tracks
+        self.features = features
+        self.cluster_func = cluster_func
+        self.cluster_params = cluster_params
+        self.library_path = library_path
+        self.log = log_callback
+
+        from sklearn.decomposition import PCA
+
+        X = np.vstack(features)
+        self.X2 = PCA(n_components=2).fit_transform(X)
+
+        labels = cluster_func(X, cluster_params)
+        colors = [f"C{l}" for l in labels]
+
+        fig = Figure(figsize=(5, 5))
+        ax = fig.add_subplot(111)
+        ax.scatter(self.X2[:, 0], self.X2[:, 1], c=colors, s=20)
+        ax.set_title("Lasso to select & generate playlist")
+        canvas = FigureCanvasTkAgg(fig, master=self)
+        canvas.get_tk_widget().pack(fill="both", expand=True)
+
+        def onselect(verts):
+            path = Path(verts)
+            mask = path.contains_points(self.X2)
+            self.selected = [tracks[i] for i, v in enumerate(mask) if v]
+            self.log(f"\u2192 {len(self.selected)} songs selected")
+
+        LassoSelector(ax, onselect)
+
+        btn = ttk.Button(self, text="Generate Playlist", command=self._on_generate)
+        btn.pack(pady=5)
+
+    def _on_generate(self):
+        if not getattr(self, "selected", []):
+            self.log("\u26A0 No songs selected")
+            return
+        playlists_dir = os.path.join(self.library_path, "Playlists")
+        os.makedirs(playlists_dir, exist_ok=True)
+        out = os.path.join(
+            playlists_dir,
+            f"Interactive_{self.cluster_params['method']}.m3u",
+        )
+        write_playlist(self.selected, out)
+        self.log(f"\u2713 Playlist written: {out}")

--- a/clustered_playlists.py
+++ b/clustered_playlists.py
@@ -128,3 +128,4 @@ def generate_clustered_playlists(tracks, root_path: str, method: str, params: di
             log_callback(f"\u2717 Failed to write {outfile}: {e}")
 
     log_callback("✓ Clustered playlist generation finished")
+    return feats

--- a/controllers/cluster_controller.py
+++ b/controllers/cluster_controller.py
@@ -20,8 +20,8 @@ def gather_tracks(library_path: str) -> list[str]:
     return tracks
 
 
-def cluster_library(library_path: str, method: str, num: int, log_callback) -> None:
-    """Generate clustered playlists for ``library_path``."""
+def cluster_library(library_path: str, method: str, num: int, log_callback):
+    """Generate clustered playlists for ``library_path`` and return features."""
     tracks = gather_tracks(library_path)
     log_path = os.path.join(library_path, f"{method}_log.txt")
 
@@ -35,4 +35,6 @@ def cluster_library(library_path: str, method: str, num: int, log_callback) -> N
 
     log(f"Found {len(tracks)} audio files")
     params = {"n_clusters": num} if method == "kmeans" else {"min_cluster_size": num}
-    generate_clustered_playlists(tracks, library_path, method, params, log)
+    feats = generate_clustered_playlists(tracks, library_path, method, params, log)
+    return tracks, feats
+

--- a/playlist_generator.py
+++ b/playlist_generator.py
@@ -87,3 +87,13 @@ def generate_playlists(
         except Exception as e:
             log_callback(f"\u2717 Failed to write {playlist_file}: {e}")
 
+
+def write_playlist(tracks, outfile):
+    """Write a simple M3U playlist from ``tracks`` to ``outfile``."""
+    os.makedirs(os.path.dirname(outfile), exist_ok=True)
+    try:
+        with open(outfile, "w", encoding="utf-8") as f:
+            for p in tracks:
+                f.write(os.path.relpath(p, os.path.dirname(outfile)) + "\n")
+    except Exception as e:
+        raise RuntimeError(f"Failed to write playlist {outfile}: {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ scipy
 numpy
 scikit-learn
 hdbscan
+matplotlib
 requests
 # optional metadata helpers
 spotipy


### PR DESCRIPTION
## Summary
- create a reusable `ClusterGraphPanel` for interactive playlists
- expose `write_playlist` helper for manual playlist generation
- return feature vectors from the clustering controller
- add KMeans/HDBSCAN options to playlist creator
- keep clustering results in `app.cluster_data`
- add missing matplotlib dependency

## Testing
- `python -m py_compile cluster_graph_panel.py controllers/cluster_controller.py clustered_playlists.py main_gui.py playlist_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_6862e910f4d88320a882c3c0b3758951