### PR TITLE
Implement lasso mode playlist creation

### DIFF
--- a/cluster_graph_panel.py
+++ b/cluster_graph_panel.py
@@ -1,5 +1,8 @@
 import os
+from datetime import datetime
+
 import numpy as np
+import tkinter as tk
 from tkinter import ttk
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 from matplotlib.figure import Figure
@@ -10,7 +13,7 @@ from playlist_generator import write_playlist
 
 
 class ClusterGraphPanel(ttk.Frame):
-    """Interactive scatter plot for selecting clustered songs."""
+    """Interactive scatter plot with lasso selection for playlist creation."""
 
     def __init__(self, parent, tracks, features, cluster_func, cluster_params, library_path, log_callback):
         super().__init__(parent)
@@ -30,32 +33,109 @@ class ClusterGraphPanel(ttk.Frame):
         colors = [f"C{l}" for l in labels]
 
         fig = Figure(figsize=(5, 5))
-        ax = fig.add_subplot(111)
-        ax.scatter(self.X2[:, 0], self.X2[:, 1], c=colors, s=20)
-        ax.set_title("Lasso to select & generate playlist")
-        canvas = FigureCanvasTkAgg(fig, master=self)
-        canvas.get_tk_widget().pack(fill="both", expand=True)
+        self.ax = fig.add_subplot(111)
+        self.scatter = self.ax.scatter(self.X2[:, 0], self.X2[:, 1], c=colors, s=20)
+        self.ax.set_title("Lasso to select & generate playlist")
+        self.canvas = FigureCanvasTkAgg(fig, master=self)
+        self.canvas.get_tk_widget().pack(fill="both", expand=True)
 
-        def onselect(verts):
-            path = Path(verts)
-            mask = path.contains_points(self.X2)
-            self.selected = [tracks[i] for i, v in enumerate(mask) if v]
-            self.log(f"\u2192 {len(self.selected)} songs selected")
+        self.lasso = None
+        self.sel_scatter = None
+        self.selected_indices: list[int] = []
+        self.selected_tracks: list[str] = []
 
-        LassoSelector(ax, onselect)
+    # UI widgets created externally will be assigned after instantiation
+    lasso_btn: ttk.Widget
+    ok_btn: ttk.Button
+    gen_btn: ttk.Button
+    auto_var: 'tk.BooleanVar'
 
-        btn = ttk.Button(self, text="Generate Playlist", command=self._on_generate)
-        btn.pack(pady=5)
+    # ─── Lasso Handling ─────────────────────────────────────────────────────
+    def toggle_lasso(self):
+        """Enter or exit lasso selection mode."""
+        if self.lasso is None:
+            self._clear_selection()
+            self.lasso = LassoSelector(self.ax, onselect=self._on_lasso_select)
+            self.log("Lasso mode enabled – draw a shape")
+        else:
+            self.lasso.disconnect_events()
+            self.lasso = None
+            self.log("Lasso mode disabled")
+            self._clear_selection()
 
-    def _on_generate(self):
-        if not getattr(self, "selected", []):
+        self.ok_btn.configure(state="disabled")
+        self.gen_btn.configure(state="disabled")
+        self.canvas.draw_idle()
+
+    def _on_lasso_select(self, verts):
+        path = Path(verts)
+        mask = path.contains_points(self.X2)
+        self.selected_indices = [i for i, v in enumerate(mask) if v]
+        self.log(f"\u2192 {len(self.selected_indices)} songs selected")
+        self._update_highlight()
+        if self.selected_indices:
+            self.ok_btn.configure(state="normal")
+        else:
+            self.ok_btn.configure(state="disabled")
+
+    def finalize_lasso(self):
+        """Lock selection and optionally auto-create playlist."""
+        if not self.selected_indices:
+            self.log("\u26A0 No points selected; please try again.")
+            self.gen_btn.configure(state="disabled")
+            return
+
+        self.selected_tracks = [self.tracks[i] for i in self.selected_indices]
+        if self.auto_var.get():
+            self.create_playlist()
+        else:
+            self.gen_btn.configure(state="normal")
+
+    # ─── Playlist Creation ──────────────────────────────────────────────────
+    def create_playlist(self):
+        if not self.selected_tracks:
             self.log("\u26A0 No songs selected")
             return
+
         playlists_dir = os.path.join(self.library_path, "Playlists")
         os.makedirs(playlists_dir, exist_ok=True)
-        out = os.path.join(
-            playlists_dir,
-            f"Interactive_{self.cluster_params['method']}.m3u",
-        )
-        write_playlist(self.selected, out)
-        self.log(f"\u2713 Playlist written: {out}")
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        base = os.path.join(playlists_dir, f"CustomLasso_{ts}.m3u")
+        out = base
+        idx = 1
+        while os.path.exists(out):
+            out = base.replace(".m3u", f"_{idx}.m3u")
+            idx += 1
+
+        try:
+            write_playlist(self.selected_tracks, out)
+        except Exception as e:  # pragma: no cover - simple GUI log
+            self.log(f"\u2717 Failed to write playlist: {e}")
+        else:
+            self.log(f"\u2713 Playlist written: {out}")
+            self.gen_btn.configure(state="disabled")
+
+    # ─── Helpers ────────────────────────────────────────────────────────────
+    def _clear_selection(self):
+        self.selected_indices = []
+        self.selected_tracks = []
+        if self.sel_scatter is not None:
+            self.sel_scatter.remove()
+            self.sel_scatter = None
+
+    def _update_highlight(self):
+        if self.sel_scatter is not None:
+            self.sel_scatter.remove()
+        if not self.selected_indices:
+            self.sel_scatter = None
+        else:
+            pts = self.X2[self.selected_indices]
+            self.sel_scatter = self.ax.scatter(
+                pts[:, 0],
+                pts[:, 1],
+                facecolors="none",
+                edgecolors="k",
+                s=60,
+            )
+        self.canvas.draw_idle()
+

--- a/main_gui.py
+++ b/main_gui.py
@@ -146,6 +146,45 @@ def create_panel_for_plugin(app, name: str, parent: tk.Widget) -> ttk.Frame:
         log_callback=app._log,
     )
     panel.pack(fill="both", expand=True)
+
+    btn_frame = ttk.Frame(frame)
+    btn_frame.pack(side="bottom", fill="x", pady=5)
+
+    panel.lasso_var = tk.BooleanVar(value=False)
+    panel.auto_var = tk.BooleanVar(value=False)
+
+    lasso_btn = ttk.Checkbutton(
+        btn_frame,
+        text="Lasso Mode",
+        variable=panel.lasso_var,
+        command=panel.toggle_lasso,
+    )
+    lasso_btn.pack(side="left")
+    panel.lasso_btn = lasso_btn
+
+    panel.ok_btn = ttk.Button(
+        btn_frame,
+        text="OK",
+        command=panel.finalize_lasso,
+        state="disabled",
+    )
+    panel.ok_btn.pack(side="left", padx=(5, 0))
+
+    panel.gen_btn = ttk.Button(
+        btn_frame,
+        text="Generate Playlist",
+        command=panel.create_playlist,
+        state="disabled",
+    )
+    panel.gen_btn.pack(side="left", padx=(5, 0))
+
+    auto_chk = ttk.Checkbutton(
+        btn_frame,
+        text="Auto-Create",
+        variable=panel.auto_var,
+    )
+    auto_chk.pack(side="left", padx=(5, 0))
+
     return frame
 
 


### PR DESCRIPTION
## Summary
- add lasso mode and playlist generation controls to plugin panel
- implement interactive lasso selection with auto-create option

## Testing
- `python -m py_compile cluster_graph_panel.py main_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68632af5c6488320814fa52f73d140f9