### PR TITLE
Accelerate fingerprinting with process pools

### DIFF
--- a/music_indexer_api.py
+++ b/music_indexer_api.py
@@ -614,8 +614,8 @@ def apply_indexer_moves(root_path, log_callback=None, progress_callback=None):
     docs_dir = os.path.join(root_path, "Docs")
     os.makedirs(docs_dir, exist_ok=True)
     db_path = os.path.join(docs_dir, ".soundvault.db")
-    from fingerprint_generator import compute_fingerprints
-    compute_fingerprints(root_path, db_path, log_callback)
+    from fingerprint_generator import compute_fingerprints_parallel
+    compute_fingerprints_parallel(root_path, db_path, log_callback)
 
     moves, _, _ = compute_moves_and_tag_index(root_path, log_callback)
 


### PR DESCRIPTION
## Summary
- parallelize fingerprint generation using `ProcessPoolExecutor`
- wrap old API to maintain compatibility
- update indexer to call the new parallel version

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68647d41478c832089a8df1d02bc894e