### PR TITLE
Change auto-create to button in playlist tab

### DIFF
--- a/cluster_graph_panel.py
+++ b/cluster_graph_panel.py
@@ -77,7 +77,6 @@ class ClusterGraphPanel(ttk.Frame):
     lasso_btn: ttk.Widget
     ok_btn: ttk.Button
     gen_btn: ttk.Button
-    auto_var: 'tk.BooleanVar'
 
     # ─── Lasso Handling ─────────────────────────────────────────────────────
     def toggle_lasso(self):
@@ -178,17 +177,14 @@ class ClusterGraphPanel(ttk.Frame):
             self.ok_btn.configure(state="disabled")
 
     def finalize_lasso(self):
-        """Lock selection and optionally auto-create playlist."""
+        """Lock selection and enable playlist creation."""
         if not self.selected_indices:
             self.log("\u26A0 No points selected; please try again.")
             self.gen_btn.configure(state="disabled")
             return
 
         self.selected_tracks = [self.tracks[i] for i in self.selected_indices]
-        if self.auto_var.get():
-            self.create_playlist()
-        else:
-            self.gen_btn.configure(state="normal")
+        self.gen_btn.configure(state="normal")
 
     # ─── Playlist Creation ──────────────────────────────────────────────────
     def create_playlist(self):

--- a/main_gui.py
+++ b/main_gui.py
@@ -166,7 +166,6 @@ def create_panel_for_plugin(app, name: str, parent: tk.Widget) -> ttk.Frame:
     btn_frame.grid(row=2, column=0, sticky="ew", pady=5)
 
     panel.lasso_var = tk.BooleanVar(value=False)
-    panel.auto_var = tk.BooleanVar(value=False)
 
     lasso_btn = ttk.Checkbutton(
         btn_frame,
@@ -193,12 +192,21 @@ def create_panel_for_plugin(app, name: str, parent: tk.Widget) -> ttk.Frame:
     )
     panel.gen_btn.pack(side="left", padx=(5, 0))
 
-    auto_chk = ttk.Checkbutton(
-        btn_frame,
-        text="Auto-Create",
-        variable=panel.auto_var,
-    )
-    auto_chk.pack(side="left", padx=(5, 0))
+    def _auto_create_all():
+        method = panel.cluster_params.get("method")
+        num = panel.cluster_params.get("n_clusters") or panel.cluster_params.get(
+            "min_cluster_size"
+        )
+        if num is None:
+            return
+        threading.Thread(
+            target=app._run_cluster_generation,
+            args=(app.library_path, method, int(num)),
+            daemon=True,
+        ).start()
+
+    auto_btn = ttk.Button(btn_frame, text="Auto-Create", command=_auto_create_all)
+    auto_btn.pack(side="left", padx=(5, 0))
 
     # ─── Hover Metadata Panel ────────────────────────────────────────────
     hover_panel = ttk.Frame(panel, relief="solid", borderwidth=1)


### PR DESCRIPTION
## Summary
- remove auto-create checkbox logic from `ClusterGraphPanel`
- replace it with an "Auto-Create" button in playlist tab that generates all cluster playlists

## Testing
- `python -m py_compile cluster_graph_panel.py main_gui.py`
- `pytest plugins/test_plugin.py -q` *(fails: no tests collected)*

------
https://chatgpt.com/codex/tasks/task_e_68648595a93c8320acb958073ed14c57