### PR TITLE
Add Not Sorted prompt before indexing

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -639,11 +639,17 @@ class SoundVaultImporterApp(tk.Tk):
             if not self._confirm_duplicates(dups):
                 log_line("✗ Operation cancelled by user")
                 return
-        if dry_run:
-            messagebox.showinfo(
-                "Not Sorted",
-                "You can move any folders you want to keep untouched into the 'Not Sorted' folder before proceeding.",
-            )
+        # Give the user a chance to exclude files by moving them into the
+        # "Not Sorted" folder before any changes are made.
+        not_sorted = os.path.join(path, "Not Sorted")
+        os.makedirs(not_sorted, exist_ok=True)
+        messagebox.showinfo(
+            "Not Sorted",
+            (
+                "Move any folders you want the indexer to skip into the "
+                "'Not Sorted' folder, then press OK to continue."
+            ),
+        )
         # 2) Proceed with threaded indexing
         threading.Thread(target=task, daemon=True).start()
 


### PR DESCRIPTION
## Summary
- notify user to move folders into `Not Sorted` before starting the indexer

## Testing
- `python -m py_compile main_gui.py music_indexer_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6864b52f086083209ed49196f5057803