### PR TITLE
Simplify clustered playlist folder filter UI

### DIFF
--- a/controllers/cluster_controller.py
+++ b/controllers/cluster_controller.py
@@ -14,16 +14,14 @@ def gather_tracks(library_path: str, folder_filter: dict | None = None) -> list[
         else library_path
     )
 
-    mode = None
     include: list[str] = []
     exclude: list[str] = []
     if folder_filter:
-        mode = folder_filter.get("mode")
         include = [os.path.abspath(p) for p in folder_filter.get("include", [])]
         exclude = [os.path.abspath(p) for p in folder_filter.get("exclude", [])]
 
     def iter_dirs() -> list[str]:
-        if mode == "include" and include:
+        if include:
             for root in include:
                 if os.path.isdir(root):
                     yield from [root]
@@ -34,7 +32,7 @@ def gather_tracks(library_path: str, folder_filter: dict | None = None) -> list[
     for start in iter_dirs():
         for dirpath, dirs, files in os.walk(start):
             abs_dir = os.path.abspath(dirpath)
-            if mode == "exclude" and any(abs_dir.startswith(e) for e in exclude):
+            if any(abs_dir.startswith(e) for e in exclude):
                 dirs[:] = []
                 continue
             for fname in files:

--- a/main_gui.py
+++ b/main_gui.py
@@ -277,7 +277,7 @@ class SoundVaultImporterApp(tk.Tk):
 
         # Cached tracks and feature vectors for interactive clustering
         self.cluster_data = None
-        self.folder_filter = {"mode": "include", "include": [], "exclude": []}
+        self.folder_filter = {"include": [], "exclude": []}
 
         # assume ffmpeg is available without performing checks
         self.ffmpeg_available = True
@@ -814,11 +814,6 @@ class SoundVaultImporterApp(tk.Tk):
         ttk.Button(btn_exc, text="Add ➕", command=lambda: add_to(exc_list)).pack(side="left")
         ttk.Button(btn_exc, text="Remove ➖", command=lambda: remove_from(exc_list)).pack(side="left")
 
-        mode_var = tk.StringVar(value=self.folder_filter.get("mode", "include"))
-        mode_frame = ttk.Frame(dlg)
-        mode_frame.pack(fill="x")
-        ttk.Radiobutton(mode_frame, text="Include mode", variable=mode_var, value="include").pack(side="left", padx=5)
-        ttk.Radiobutton(mode_frame, text="Exclude mode", variable=mode_var, value="exclude").pack(side="left", padx=5)
 
         for p in self.folder_filter.get("include", []):
             inc_list.insert("end", p)
@@ -830,7 +825,6 @@ class SoundVaultImporterApp(tk.Tk):
 
         def generate():
             self.folder_filter = {
-                "mode": mode_var.get(),
                 "include": list(inc_list.get(0, "end")),
                 "exclude": list(exc_list.get(0, "end")),
             }


### PR DESCRIPTION
## Summary
- drop folder filtering "mode" in `gather_tracks`
- remove include/exclude mode radios from clustering dialog
- keep just include/exclude lists for filtering

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6864bca224d08320a837302233382835