### PR TITLE
Fix dry run progress parameter

### DIFF
--- a/music_indexer_api.py
+++ b/music_indexer_api.py
@@ -675,7 +675,7 @@ def build_dry_run_html(root_path, output_html_path, log_callback=None):
     if log_callback is None:
         def log_callback(msg): pass
 
-    moves, tag_index, _ = compute_moves_and_tag_index(root_path, log_callback, progress_callback)
+    moves, tag_index, _ = compute_moves_and_tag_index(root_path, log_callback)
 
     log_callback("5/6: Writing dry-run HTML…")
     with open(output_html_path, "w", encoding="utf-8") as out:


### PR DESCRIPTION
## Summary
- remove undefined `progress_callback` from `build_dry_run_html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pybind11_tests')*

------
https://chatgpt.com/codex/tasks/task_e_68680e2c6d488320972742e73769405e