### PR TITLE
Fix dry-run to avoid filesystem changes

### DIFF
--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import types
+import tempfile
+import unittest
+
+# Provide simple stubs for mutagen so the module imports
+mutagen_stub = types.ModuleType('mutagen')
+class DummyAudio:
+    def __init__(self):
+        self.tags = None
+        self.pictures = []
+mutagen_stub.File = lambda *a, **k: DummyAudio()
+
+id3_stub = types.ModuleType('id3')
+class DummyID3Error(Exception):
+    pass
+id3_stub.ID3NoHeaderError = DummyID3Error
+mutagen_stub.id3 = id3_stub
+sys.modules['mutagen'] = mutagen_stub
+sys.modules['mutagen.id3'] = id3_stub
+
+from music_indexer_api import build_dry_run_html
+
+class DryRunTest(unittest.TestCase):
+    def test_dry_run_does_not_modify_files(self):
+        with tempfile.TemporaryDirectory() as root:
+            os.makedirs(os.path.join(root, 'A'), exist_ok=True)
+            os.makedirs(os.path.join(root, 'B'), exist_ok=True)
+            open(os.path.join(root, 'A', 'dup.mp3'), 'wb').close()
+            open(os.path.join(root, 'B', 'dup.mp3'), 'wb').close()
+
+            before_files = {
+                os.path.relpath(os.path.join(dp, f), root)
+                for dp, _, fs in os.walk(root)
+                for f in fs
+            }
+
+            html = os.path.join(root, 'index.html')
+            build_dry_run_html(root, html)
+
+            after_files = {
+                os.path.relpath(os.path.join(dp, f), root)
+                for dp, _, fs in os.walk(root)
+                for f in fs
+            }
+
+            # Original audio files should remain untouched
+            self.assertTrue({'A/dup.mp3', 'B/dup.mp3'}.issubset(after_files))
+            self.assertEqual(before_files, {'A/dup.mp3', 'B/dup.mp3'})
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a `dry_run` flag to `compute_moves_and_tag_index`
- use the flag when generating dry‑run HTML and duplicate listings
- skip duplicate move/delete operations when `dry_run` is enabled
- update `run_full_indexer` and `apply_indexer_moves` calls
- add a simple test covering the dry-run behaviour

## Testing
- `python -m pytest tests/test_dry_run.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6868117d3ad883208fd9918bb39ab56b