### PR TITLE
Improve scanning progress callbacks

### DIFF
--- a/fingerprint_generator.py
+++ b/fingerprint_generator.py
@@ -84,6 +84,7 @@ def compute_fingerprints_parallel(
     )
 
     audio_files = []
+    idx = 0
     for dirpath, _, files in os.walk(root_path):
         rel_dir = os.path.relpath(dirpath, root_path)
         if "Not Sorted" in rel_dir.split(os.sep):
@@ -91,7 +92,10 @@ def compute_fingerprints_parallel(
         for fname in files:
             ext = os.path.splitext(fname)[1].lower()
             if ext in SUPPORTED_EXTS:
-                audio_files.append(os.path.join(dirpath, fname))
+                full = os.path.join(dirpath, fname)
+                audio_files.append(full)
+                idx += 1
+                progress_callback(idx, 0, os.path.relpath(full, root_path))
 
     total = len(audio_files)
     progress_callback(0, total, "Fingerprinting")


### PR DESCRIPTION
## Summary
- support `progress_callback` in `build_primary_counts`
- remove extra directory pass in `compute_moves_and_tag_index`
- update fingerprint generator to report discovery progress
- allow optional progress callback when counting audio files

## Testing
- `PYTHONPATH=. pytest tests/test_dry_run.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686826ab0fe08320b39203941cc0f127