### PR TITLE
Add dry-run fingerprinting and distance logging

### DIFF
--- a/music_indexer_api.py
+++ b/music_indexer_api.py
@@ -303,6 +303,13 @@ def compute_moves_and_tag_index(root_path, log_callback=None, progress_callback=
             (fullpath,),
         ).fetchone()
         fp = row[0] if row else None
+        if dry_run and not fp:
+            try:
+                import acoustid  # local import to avoid dependency when unused
+                _, fp_hash = acoustid.fingerprint_file(fullpath)
+                fp = fp_hash
+            except Exception:
+                fp = None
         file_infos[fullpath] = {
             "primary": primary.lower(),
             "title": title.lower(),

--- a/near_duplicate_detector.py
+++ b/near_duplicate_detector.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import os
 from collections import defaultdict
 from typing import Dict, Set, List
+import logging
+
+logger = logging.getLogger(__name__)
 
 from music_indexer_api import _keep_score
 
@@ -52,10 +55,14 @@ def find_near_duplicates(
     for i, p in enumerate(paths):
         for q in paths[i + 1:]:
             dist = fingerprint_distance(file_infos[p]['fp'], file_infos[q]['fp'])
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    f"Dry-run: {p} vs {q}: Hamming distance = {dist}")
             if dist <= threshold:
                 adj[p].add(q)
                 adj[q].add(p)
-                log_callback(f"   → near-dup {os.path.basename(p)} vs {os.path.basename(q)} dist={dist:.3f}")
+                log_callback(
+                    f"   → near-dup {os.path.basename(p)} vs {os.path.basename(q)} dist={dist:.3f}")
 
     # Compute connected components
     visited: Set[str] = set()


### PR DESCRIPTION
## Summary
- compute fingerprints on the fly during dry-run
- add debug logging in near-duplicate detection

## Testing
- `PYTHONPATH=. pytest tests/test_dry_run.py -q`
- `python -m music_indexer_api --dry-run` *(fails: No module named 'mutagen')*

------
https://chatgpt.com/codex/tasks/task_e_68682aa824248320b704d20db3673692