### PR TITLE
Fix indentation in progress callback

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -738,7 +738,7 @@ class SoundVaultImporterApp(tk.Tk):
 
             self.after(0, ui)
 
-       def progress(idx, total, path_):
+        def progress(idx, total, path_):
             def ui():
                 if total:
                     if self.pb["mode"] != "determinate":


### PR DESCRIPTION
## Summary
- fix indentation for the progress callback in `main_gui.py`

## Testing
- `PYTHONPATH=. pytest tests/test_dry_run.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6868c9ab59748320b3b51b127767d744