### PR TITLE
Fix fingerprint cache column error

### DIFF
--- a/fingerprint_cache.py
+++ b/fingerprint_cache.py
@@ -16,6 +16,19 @@ def _ensure_db(db_path: str) -> sqlite3.Connection:
         );
         """
     )
+
+    # --- Handle schema upgrades -------------------------------------------
+    cols = {
+        row[1] for row in conn.execute("PRAGMA table_info(fingerprints)")
+    }
+    if "mtime" not in cols:
+        conn.execute("ALTER TABLE fingerprints ADD COLUMN mtime REAL")
+    if "duration" not in cols:
+        conn.execute("ALTER TABLE fingerprints ADD COLUMN duration INT")
+    if "fingerprint" not in cols:
+        conn.execute("ALTER TABLE fingerprints ADD COLUMN fingerprint TEXT")
+    conn.commit()
+
     return conn
 
 


### PR DESCRIPTION
## Summary
- handle missing columns in fingerprint cache database when opening

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f82f5e20832082c77d58e60bfe4a