### PR TITLE
Add album-partitioned near-duplicate detection

### DIFF
--- a/music_indexer_api.py
+++ b/music_indexer_api.py
@@ -405,6 +405,7 @@ def compute_moves_and_tag_index(
         log_callback,
         enable_phase_c,
         coord,
+        max_workers,
     )
     for loser, reason in near_dupes.items():
         if loser not in to_delete:
@@ -737,9 +738,6 @@ def build_dry_run_html(
         lines.append("</pre>")
         return "\n".join(lines)
 
-    def build_album_near_dupe_section() -> str:
-        return "<h2>Phase B – Album Near-Duplicates</h2>"
-
     def build_cross_album_section() -> str:
         if not enable_phase_c:
             return ""
@@ -747,8 +745,6 @@ def build_dry_run_html(
 
     sec_a = build_exact_metadata_section()
     coord.set_html_section('A', sec_a)
-    sec_b = build_album_near_dupe_section()
-    coord.set_html_section('B', sec_b)
     sec_c = build_cross_album_section()
     if sec_c:
         coord.set_html_section('C', sec_c)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -21,6 +21,6 @@ def test_phase_b_logging(caplog):
     with caplog.at_level(logging.DEBUG):
         find_near_duplicates(infos, {'.mp3':0}, 1.0, enable_cross_album=False)
     msgs = [r.message for r in caplog.records]
-    assert any('Phase B: scanning album A' in m for m in msgs)
+    assert any('Scanning album' in m and "'A'" in m for m in msgs)
     assert any('Phase B summary' in m for m in msgs)
 

--- a/tests/test_phase_b.py
+++ b/tests/test_phase_b.py
@@ -1,0 +1,42 @@
+import types
+import sys
+
+mutagen_stub = types.ModuleType('mutagen')
+mutagen_stub.File = lambda *a, **k: None
+id3_stub = types.ModuleType('id3')
+id3_stub.ID3NoHeaderError = Exception
+mutagen_stub.id3 = id3_stub
+sys.modules['mutagen'] = mutagen_stub
+sys.modules['mutagen.id3'] = id3_stub
+
+from dry_run_coordinator import DryRunCoordinator
+from near_duplicate_detector import find_near_duplicates
+
+
+def test_phase_b_clusters_and_html():
+    infos = {
+        'a1': {'fp': '1 2', 'album': 'A', 'title': 't', 'meta_count': 1},
+        'a2': {'fp': '1 2', 'album': 'A', 'title': 't', 'meta_count': 1},
+        'b1': {'fp': '3 4', 'album': 'B', 'title': 't', 'meta_count': 1},
+        'b2': {'fp': '3 4', 'album': 'B', 'title': 't', 'meta_count': 1},
+    }
+    coord = DryRunCoordinator()
+    find_near_duplicates(infos, {'.mp3': 0}, 1.0, coord=coord)
+    clusters = [set(c) for c in coord.near_dupe_clusters]
+    assert {frozenset({'a1', 'a2'}), frozenset({'b1', 'b2'})} == {frozenset(c) for c in clusters}
+    assert 'Phase B – Album Near-Duplicates' in coord._sections.get('B', '')
+
+
+def test_phase_b_error(monkeypatch):
+    infos = {
+        'x1': {'fp': '1', 'album': 'X', 'title': 't', 'meta_count': 1},
+        'x2': {'fp': '2', 'album': 'X', 'title': 't', 'meta_count': 1},
+    }
+
+    def boom(*a, **k):
+        raise RuntimeError('boom')
+
+    monkeypatch.setattr('near_duplicate_detector.fingerprint_distance', boom)
+    coord = DryRunCoordinator()
+    find_near_duplicates(infos, {'.mp3': 0}, 1.0, coord=coord)
+    assert 'Error scanning album' in coord._sections.get('B', '')


### PR DESCRIPTION
## Summary
- parallelize Phase B in `find_near_duplicates`
- push Phase B HTML from near-duplicate detector
- update coordinator usage in `music_indexer_api`
- test logging expectations and new Phase B behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686991fa0e6c8320a71bcd3a99178d35