### PR TITLE
Fix mis-triggered progress bar by tagging phases

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -825,17 +825,15 @@ class SoundVaultImporterApp(tk.Tk):
 
             self.after(0, ui)
 
-        def progress(idx, total, path_):
+        def progress(idx, total, path_, phase="A"):
             if cancel_event.is_set():
                 raise IndexCancelled()
             def ui():
-                msg = path_.lower()
-                if "metadata" in msg:
-                    bar = self.phase_b_bar
-                elif "moving" in msg or "apply" in msg:
-                    bar = self.phase_c_bar
-                else:
-                    bar = self.phase_a_bar
+                bar = {
+                    "A": self.phase_a_bar,
+                    "B": self.phase_b_bar,
+                    "C": self.phase_c_bar,
+                }.get(phase, self.phase_a_bar)
 
                 if total:
                     if bar["mode"] != "determinate":


### PR DESCRIPTION
## Summary
- include phase identifier in `progress_callback` to avoid string checks
- update GUI to use the explicit phase when selecting bars
- propagate phase info through indexer and fingerprinting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874196842288320a03ca3f2a790a1c2