### PR TITLE
Fix fingerprint cache on missing files

### DIFF
--- a/fingerprint_cache.py
+++ b/fingerprint_cache.py
@@ -43,7 +43,11 @@ def get_fingerprint(
     """Return fingerprint for path using cache; compute if missing."""
     path = ensure_long_path(path)
     conn = _ensure_db(db_path)
-    mtime = os.path.getmtime(path)
+    try:
+        mtime = os.path.getmtime(path)
+    except OSError:
+        conn.close()
+        return None
     row = conn.execute(
         "SELECT mtime, fingerprint FROM fingerprints WHERE path=?",
         (path,),

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -82,3 +82,16 @@ def test_long_path_support(tmp_path):
     fp = get_fingerprint(str(path), str(db), compute)
     assert fp == "hash"
 
+
+def test_missing_file_returns_none(tmp_path):
+    db = tmp_path / "fp.db"
+    path = tmp_path / "a.mp3"
+    path.write_text("x")
+    path.unlink()
+
+    def compute(_):
+        raise AssertionError("compute should not be called")
+
+    fp = get_fingerprint(str(path), str(db), compute)
+    assert fp is None
+


### PR DESCRIPTION
## Summary
- guard `os.path.getmtime` against missing file errors in `get_fingerprint`
- regression test for deleted file handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ba45d780c832098605d9c09fe1ec6