### PR TITLE
Enable long path support for tag fixer

### DIFF
--- a/plugins/acoustid_plugin.py
+++ b/plugins/acoustid_plugin.py
@@ -3,6 +3,7 @@ import musicbrainzngs
 from itertools import islice
 
 from plugins.base import MetadataPlugin
+from utils.path_helpers import ensure_long_path
 from tag_fixer import (
     ACOUSTID_API_KEY,
     ACOUSTID_APP_NAME,
@@ -18,7 +19,7 @@ musicbrainzngs.set_useragent(
 class AcoustIDPlugin(MetadataPlugin):
     def identify(self, file_path: str) -> dict:
         try:
-            match_gen = acoustid.match(ACOUSTID_API_KEY, file_path)
+            match_gen = acoustid.match(ACOUSTID_API_KEY, ensure_long_path(file_path))
             peek = list(islice(match_gen, 5))
             if not peek:
                 return {}

--- a/plugins/lastfm.py
+++ b/plugins/lastfm.py
@@ -4,6 +4,7 @@ from typing import List
 
 import requests
 from mutagen import File as MutagenFile
+from utils.path_helpers import ensure_long_path
 
 from plugins.base import MetadataPlugin
 
@@ -15,7 +16,7 @@ class LastfmPlugin(MetadataPlugin):
     def identify(self, file_path: str) -> dict:
         if not API_KEY:
             return {}
-        audio = MutagenFile(file_path, easy=True)
+        audio = MutagenFile(ensure_long_path(file_path), easy=True)
         artist = (audio.tags.get("artist") or [None])[0] if audio and audio.tags else None
         title = (audio.tags.get("title") or [None])[0] if audio and audio.tags else None
         if not artist or not title:

--- a/tag_fixer.py
+++ b/tag_fixer.py
@@ -7,6 +7,7 @@ from typing import Iterable, Callable, List, Optional
 import pkgutil
 import importlib
 from mutagen import File as MutagenFile
+from utils.path_helpers import ensure_long_path
 
 from plugins.base import MetadataPlugin
 
@@ -90,7 +91,7 @@ def is_remix(audio_path):
     """Return True if filename or existing title suggests a remix."""
     if "remix" in os.path.basename(audio_path).lower():
         return True
-    audio = MutagenFile(audio_path, easy=True)
+    audio = MutagenFile(ensure_long_path(audio_path), easy=True)
     if audio and audio.tags and "title" in audio.tags:
         title = " ".join(audio.tags["title"]).lower()
         if "remix" in title:
@@ -111,7 +112,7 @@ def find_files(root):
 
 def update_tags(path: str, proposal: FileRecord, fields: List[str], log_callback):
     """Write selected tags from ``proposal`` into ``path``. Return True if saved."""
-    audio = MutagenFile(path, easy=True)
+    audio = MutagenFile(ensure_long_path(path), easy=True)
     if audio is None:
         return False
     changed = False
@@ -204,7 +205,7 @@ def build_file_records(
 
         log_callback(f"Processing {f}")
 
-        audio = MutagenFile(f, easy=True)
+        audio = MutagenFile(ensure_long_path(f), easy=True)
         old_artist = (audio.tags.get("artist") or [None])[0] if audio and audio.tags else None
         old_title = (audio.tags.get("title") or [None])[0] if audio and audio.tags else None
         old_album = (audio.tags.get("album") or [None])[0] if audio and audio.tags else None

--- a/tests/test_tag_fixer.py
+++ b/tests/test_tag_fixer.py
@@ -1,0 +1,75 @@
+import os
+import types
+import sys
+import importlib
+
+from plugins.base import MetadataPlugin
+
+
+class DummyPlugin(MetadataPlugin):
+    def identify(self, file_path: str) -> dict:
+        return {"artist": "NewA", "title": "NewT", "score": 1.0}
+
+
+def test_fix_tags_long_paths(tmp_path, monkeypatch):
+    # Stub dependencies
+    mutagen_stub = types.ModuleType('mutagen')
+
+    class DummyAudio:
+        def __init__(self):
+            self.tags = {}
+            self.saved = False
+
+        def __setitem__(self, key, value):
+            self.tags[key] = value
+
+        def save(self):
+            self.saved = True
+
+    def File(*_a, **_k):
+        return DummyAudio()
+
+    mutagen_stub.File = File
+    id3_stub = types.ModuleType('id3')
+    id3_stub.ID3NoHeaderError = Exception
+    mutagen_stub.id3 = id3_stub
+    monkeypatch.setitem(sys.modules, 'mutagen', mutagen_stub)
+    monkeypatch.setitem(sys.modules, 'mutagen.id3', id3_stub)
+
+    acoustid_stub = types.ModuleType('acoustid')
+
+    def match(_key, _path):
+        yield (1.0, None, 'Song', 'Artist')
+
+    acoustid_stub.match = match
+    acoustid_stub.NoBackendError = Exception
+    acoustid_stub.FingerprintGenerationError = Exception
+    acoustid_stub.WebServiceError = Exception
+    monkeypatch.setitem(sys.modules, 'acoustid', acoustid_stub)
+
+    musicbrainzngs_stub = types.ModuleType('musicbrainzngs')
+    musicbrainzngs_stub.set_useragent = lambda *a, **k: None
+    musicbrainzngs_stub.get_recording_by_id = lambda *a, **k: {"recording": {}}
+    monkeypatch.setitem(sys.modules, 'musicbrainzngs', musicbrainzngs_stub)
+
+    requests_stub = types.ModuleType('requests')
+    requests_stub.get = lambda *a, **k: types.SimpleNamespace(json=lambda: {})
+    monkeypatch.setitem(sys.modules, 'requests', requests_stub)
+
+    import tag_fixer
+
+    importlib.reload(tag_fixer)
+    tag_fixer.PLUGINS = [DummyPlugin()]
+
+    base = tmp_path
+    for i in range(6):
+        base = base / ("d" * 50 + str(i))
+    base.mkdir(parents=True)
+    path = base / "dummy_song.mp3"
+    path.write_text("x")
+
+    monkeypatch.setattr(tag_fixer, "MutagenFile", File)
+
+    summary = tag_fixer.fix_tags(str(base), log_callback=lambda m: None)
+    assert summary["processed"] == 1
+    assert summary["updated"] == 1


### PR DESCRIPTION
## Summary
- ensure long path paths are expanded when tag fixer or plugins open files
- add regression test for long path tag fixing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf3bafc7c8320b3e4f5c51f59ec1a