### PR TITLE
Handle corrupted audio files gracefully

### DIFF
--- a/plugins/lastfm.py
+++ b/plugins/lastfm.py
@@ -16,7 +16,10 @@ class LastfmPlugin(MetadataPlugin):
     def identify(self, file_path: str) -> dict:
         if not API_KEY:
             return {}
-        audio = MutagenFile(ensure_long_path(file_path), easy=True)
+        try:
+            audio = MutagenFile(ensure_long_path(file_path), easy=True)
+        except Exception:
+            return {}
         artist = (audio.tags.get("artist") or [None])[0] if audio and audio.tags else None
         title = (audio.tags.get("title") or [None])[0] if audio and audio.tags else None
         if not artist or not title:

--- a/tag_fixer.py
+++ b/tag_fixer.py
@@ -91,7 +91,10 @@ def is_remix(audio_path):
     """Return True if filename or existing title suggests a remix."""
     if "remix" in os.path.basename(audio_path).lower():
         return True
-    audio = MutagenFile(ensure_long_path(audio_path), easy=True)
+    try:
+        audio = MutagenFile(ensure_long_path(audio_path), easy=True)
+    except Exception:
+        return False
     if audio and audio.tags and "title" in audio.tags:
         title = " ".join(audio.tags["title"]).lower()
         if "remix" in title:
@@ -112,7 +115,11 @@ def find_files(root):
 
 def update_tags(path: str, proposal: FileRecord, fields: List[str], log_callback):
     """Write selected tags from ``proposal`` into ``path``. Return True if saved."""
-    audio = MutagenFile(ensure_long_path(path), easy=True)
+    try:
+        audio = MutagenFile(ensure_long_path(path), easy=True)
+    except Exception as e:
+        log_callback(f"Failed to read {path}: {e}")
+        return False
     if audio is None:
         return False
     changed = False
@@ -205,7 +212,13 @@ def build_file_records(
 
         log_callback(f"Processing {f}")
 
-        audio = MutagenFile(ensure_long_path(f), easy=True)
+        try:
+            audio = MutagenFile(ensure_long_path(f), easy=True)
+        except Exception as e:
+            log_callback(f"Failed to read {f}: {e}")
+            if progress_callback:
+                progress_callback(idx)
+            continue
         old_artist = (audio.tags.get("artist") or [None])[0] if audio and audio.tags else None
         old_title = (audio.tags.get("title") or [None])[0] if audio and audio.tags else None
         old_album = (audio.tags.get("album") or [None])[0] if audio and audio.tags else None

--- a/tests/test_tag_fixer.py
+++ b/tests/test_tag_fixer.py
@@ -73,3 +73,44 @@ def test_fix_tags_long_paths(tmp_path, monkeypatch):
     summary = tag_fixer.fix_tags(str(base), log_callback=lambda m: None)
     assert summary["processed"] == 1
     assert summary["updated"] == 1
+
+
+def test_corrupted_files_are_skipped(tmp_path, monkeypatch):
+    mutagen_stub = types.ModuleType('mutagen')
+
+    def File(*_a, **_k):
+        raise Exception('bad file')
+
+    mutagen_stub.File = File
+    id3_stub = types.ModuleType('id3')
+    id3_stub.ID3NoHeaderError = Exception
+    mutagen_stub.id3 = id3_stub
+    monkeypatch.setitem(sys.modules, 'mutagen', mutagen_stub)
+    monkeypatch.setitem(sys.modules, 'mutagen.id3', id3_stub)
+
+    import tag_fixer
+    import importlib
+    importlib.reload(tag_fixer)
+    tag_fixer.PLUGINS = []
+
+    path = tmp_path / 'bad.mp3'
+    path.write_text('x')
+
+    monkeypatch.setattr(tag_fixer, 'MutagenFile', File)
+
+    # is_remix should not raise and should return False
+    assert tag_fixer.is_remix(str(path)) is False
+
+    import sqlite3
+    db_path = tmp_path / 'db.sqlite'
+    tag_fixer.init_db(str(db_path))
+    db = sqlite3.connect(str(db_path))
+    records = tag_fixer.build_file_records(
+        str(tmp_path), db_conn=db, log_callback=lambda m: None
+    )
+    assert records == []
+
+    summary = tag_fixer.fix_tags(str(tmp_path), log_callback=lambda m: None)
+    assert summary['processed'] == 1
+    assert summary['updated'] == 0
+


### PR DESCRIPTION
## Summary
- avoid crashing when opening files in `is_remix`
- skip unreadable files in `build_file_records`
- guard `MutagenFile` access in `update_tags`
- make Last.fm plugin resilient to corrupted files
- test skipping of corrupted audio

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c16c5ad60832084ef00331bfff50c