### PR TITLE
Add debug window for tag fixing

### DIFF
--- a/controllers/tagfix_controller.py
+++ b/controllers/tagfix_controller.py
@@ -29,7 +29,13 @@ def discover_files(folder: str) -> List[str]:
     return find_files(folder)
 
 
-def gather_records(folder: str, db_path: str, show_all: bool, progress_callback: Callable[[int], None] | None) -> List[FileRecord]:
+def gather_records(
+    folder: str,
+    db_path: str,
+    show_all: bool,
+    progress_callback: Callable[[int], None] | None,
+    log_callback: Callable[[str], None] | None = None,
+) -> List[FileRecord]:
     """Build FileRecord objects for ``folder``."""
     db_folder = os.path.dirname(db_path)
     os.makedirs(db_folder, exist_ok=True)
@@ -38,7 +44,7 @@ def gather_records(folder: str, db_path: str, show_all: bool, progress_callback:
         folder,
         db_conn=conn,
         show_all=show_all,
-        log_callback=lambda m: None,
+        log_callback=log_callback or (lambda m: None),
         progress_callback=progress_callback,
     )
     conn.commit()


### PR DESCRIPTION
## Summary
- extend `gather_records` to accept a log callback
- add `Verbose Debug` option and debug window in GUI
- route tag-fixing logs to the debug window when enabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c1ae320648320ba5da622d749aea2