### PR TITLE
Implement library sync comparison engine

### DIFF
--- a/config.py
+++ b/config.py
@@ -12,6 +12,12 @@ SUPPORTED_SERVICES = [
     "Gracenote",
 ]
 
+# Threshold for considering two tracks as near-duplicates when syncing
+NEAR_DUPLICATE_THRESHOLD = 0.1
+
+# File format quality priority used during Library Sync
+FORMAT_PRIORITY = {".flac": 3, ".wav": 2, ".mp3": 1}
+
 
 def load_config():
     """Load configuration from ``CONFIG_PATH``.

--- a/library_sync.py
+++ b/library_sync.py
@@ -1,0 +1,92 @@
+"""Helpers for comparing an existing library to an incoming folder."""
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Tuple
+
+import music_indexer_api as idx
+from fingerprint_cache import get_fingerprint
+from near_duplicate_detector import fingerprint_distance
+from config import NEAR_DUPLICATE_THRESHOLD, FORMAT_PRIORITY
+
+
+def _compute_fp(path: str) -> tuple[int | None, str | None]:
+    try:
+        import acoustid
+        return acoustid.fingerprint_file(path)
+    except Exception:
+        return None, None
+
+
+def _scan_folder(folder: str, db_path: str) -> Dict[str, Dict[str, object]]:
+    infos: Dict[str, Dict[str, object]] = {}
+    for dirpath, _dirs, files in os.walk(folder):
+        for fname in files:
+            ext = os.path.splitext(fname)[1].lower()
+            if ext not in idx.SUPPORTED_EXTS:
+                continue
+            path = os.path.join(dirpath, fname)
+            tags = idx.get_tags(path)
+            fp = get_fingerprint(path, db_path, _compute_fp)
+            bitrate = 0
+            try:
+                audio = idx.MutagenFile(path)
+                if audio and getattr(audio, "info", None):
+                    bitrate = getattr(audio.info, "bitrate", 0) or getattr(audio.info, "sample_rate", 0) or 0
+            except Exception:
+                pass
+            infos[path] = {
+                **tags,
+                "fp": fp,
+                "ext": ext,
+                "bitrate": bitrate,
+            }
+    return infos
+
+
+def compute_quality_score(info: Dict[str, object], fmt_priority: Dict[str, int]) -> int:
+    pr = fmt_priority.get(info.get("ext"), 0)
+    br = int(info.get("bitrate") or 0)
+    return pr * br
+
+
+def compare_libraries(
+    library_folder: str,
+    incoming_folder: str,
+    db_path: str,
+    threshold: float | None = None,
+    fmt_priority: Dict[str, int] | None = None,
+) -> Dict[str, object]:
+    """Return classification of incoming files vs. an existing library."""
+    threshold = threshold if threshold is not None else NEAR_DUPLICATE_THRESHOLD
+    fmt_priority = fmt_priority or FORMAT_PRIORITY
+    lib_infos = _scan_folder(library_folder, db_path)
+    inc_infos = _scan_folder(incoming_folder, db_path)
+
+    new: List[str] = []
+    existing: List[Tuple[str, str]] = []
+    improved: List[Tuple[str, str]] = []
+
+    for inc_path, inc_info in inc_infos.items():
+        best_match = None
+        best_dist = 1.0
+        for lib_path, lib_info in lib_infos.items():
+            dist = fingerprint_distance(inc_info.get("fp"), lib_info.get("fp"))
+            if dist == 0:
+                best_match = lib_path
+                best_dist = 0
+                break
+            if dist <= threshold and dist < best_dist:
+                best_match = lib_path
+                best_dist = dist
+        if best_match is None:
+            new.append(inc_path)
+            continue
+        inc_score = compute_quality_score(inc_info, fmt_priority)
+        lib_score = compute_quality_score(lib_infos[best_match], fmt_priority)
+        if inc_score > lib_score:
+            improved.append((inc_path, best_match))
+        else:
+            existing.append((inc_path, best_match))
+
+    return {"new": new, "existing": existing, "improved": improved}

--- a/playlist_generator.py
+++ b/playlist_generator.py
@@ -107,3 +107,16 @@ def write_playlist(tracks, outfile):
                 f.write(os.path.relpath(p, os.path.dirname(outfile)) + "\n")
     except Exception as e:
         raise RuntimeError(f"Failed to write playlist {outfile}: {e}")
+
+
+def update_playlists(new_tracks):
+    """Placeholder for playlist update hook used by Library Sync."""
+    # The real implementation would update any smart playlists
+    # that should include ``new_tracks``. For now we simply call
+    # ``generate_playlists`` treating each parent folder as a playlist.
+    root = os.path.commonpath(new_tracks) if new_tracks else None
+    if not root:
+        return
+    moves = {p: p for p in new_tracks}
+    generate_playlists(moves, root, overwrite=False, log_callback=lambda m: None)
+

--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -1,0 +1,70 @@
+import types
+import sys
+import os
+
+# Stub mutagen and acoustid
+mutagen_stub = types.ModuleType('mutagen')
+class DummyAudio:
+    def __init__(self, bitrate=128000):
+        self.tags = {'artist': ['A'], 'title': ['T'], 'album': ['AL']}
+        self.info = types.SimpleNamespace(bitrate=bitrate)
+
+def File(path, easy=False):
+    return DummyAudio()
+mutagen_stub.File = File
+id3_stub = types.ModuleType('id3')
+id3_stub.ID3NoHeaderError = Exception
+mutagen_stub.id3 = id3_stub
+sys.modules['mutagen'] = mutagen_stub
+sys.modules['mutagen.id3'] = id3_stub
+
+acoustid_stub = types.ModuleType('acoustid')
+fp_map = {
+    'a.flac': '1 2',
+    'b.mp3': '2 3',
+    'b.flac': '2 3',
+    'new.mp3': '9 9',
+}
+acoustid_stub.fingerprint_file = lambda p: (0, fp_map.get(os.path.basename(p), 'x'))
+sys.modules['acoustid'] = acoustid_stub
+
+import importlib
+import music_indexer_api
+importlib.reload(music_indexer_api)
+import library_sync
+importlib.reload(library_sync)
+from library_sync import compare_libraries, compute_quality_score
+from fingerprint_cache import flush_cache
+
+
+def test_quality_score_simple():
+    info = {'ext': '.flac', 'bitrate': 1000}
+    score = compute_quality_score(info, {'.flac': 3, '.mp3': 1})
+    assert score == 3000
+
+
+def test_compare_libraries(tmp_path):
+    lib = tmp_path / 'lib'
+    inc = tmp_path / 'inc'
+    lib.mkdir()
+    inc.mkdir()
+    (lib / 'a.flac').write_text('x')
+    (lib / 'b.mp3').write_text('x')
+    (inc / 'a.flac').write_text('x')
+    (inc / 'b.flac').write_text('x')
+    (inc / 'new.mp3').write_text('x')
+
+    db = tmp_path / 'fp.db'
+    res = compare_libraries(str(lib), str(inc), str(db))
+
+    new_set = set(res['new'])
+    assert str(inc / 'new.mp3') in new_set
+
+    ex_pairs = set(res['existing'])
+    assert (str(inc / 'a.flac'), str(lib / 'a.flac')) in ex_pairs
+
+    imp_pairs = set(res['improved'])
+    assert (str(inc / 'b.flac'), str(lib / 'b.mp3')) in imp_pairs
+
+    # cleanup cache between tests
+    flush_cache(str(db))


### PR DESCRIPTION
## Summary
- add configuration options for near-duplicate threshold and format priority
- implement `library_sync` module for comparing existing libraries and incoming folders
- hook playlist updates via `playlist_generator.update_playlists`
- test quality scoring and matching logic for library sync

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c2ef30f048320bfe74e55eaae0d6f