### PR TITLE
Improve connection settings persistence

### DIFF
--- a/metadata_service.py
+++ b/metadata_service.py
@@ -7,11 +7,20 @@ from utils.path_helpers import ensure_long_path
 def query_acoustid(api_key: str, audio_file: str) -> Dict:
     """Query AcoustID for ``audio_file`` using ``api_key``.
 
-    Returns a metadata dict or raises on failure.
+    If ``audio_file`` is an empty string a lightweight request is issued to
+    verify connectivity and API key validity. An empty dictionary is
+    returned in this case.
     """
     import acoustid
     import musicbrainzngs
     from itertools import islice
+    import requests
+
+    if not audio_file:
+        url = "https://api.acoustid.org/v2/user/status"
+        resp = requests.get(url, params={"client": api_key}, timeout=5)
+        resp.raise_for_status()
+        return {}
 
     match_gen = acoustid.match(api_key, ensure_long_path(audio_file))
     peek = list(islice(match_gen, 5))

--- a/plugins/acoustid_plugin.py
+++ b/plugins/acoustid_plugin.py
@@ -48,6 +48,12 @@ class AcoustIDPlugin(MetadataPlugin):
         result = {"ok": False}
 
         def do_test() -> None:
+            cfg = load_config()
+            cfg["metadata_service"] = service_var.get()
+            cfg["metadata_api_key"] = api_var.get()
+            save_config(cfg)
+            if service_var.get() == "AcoustID":
+                tag_fixer.ACOUSTID_API_KEY = api_var.get()
             try:
                 query_metadata(service_var.get(), api_var.get(), "")
             except Exception:


### PR DESCRIPTION
## Summary
- save service and API key whenever the user tests the connection
- check AcoustID connectivity by hitting the API directly

## Testing
- `PYTHONDONTWRITEBYTECODE=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d1000782c8320bca9d8cf5a352453