### PR TITLE
Persist metadata credentials and improve connection test

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ The configuration file also stores your selected metadata service and API key:
   "metadata_api_key": "YOUR_KEY"
 }
 ```
+These values are updated whenever you use the Tag Fixer's connection dialog.
+Testing the connection or saving will persist your selections for future runs.
 
 ## File Overview
 


### PR DESCRIPTION
## Summary
- preserve selected metadata service and API key across runs
- update the connection dialog so testing also saves the settings
- verify AcoustID connectivity via HTTP when testing
- document config persistence in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d1000782c8320bca9d8cf5a352453