### PR TITLE
Add configurable metadata service layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ threshold used during deduplication, add a value like:
 
 Lower values require more similar fingerprints.
 
-The configuration file also stores your selected metadata service and API key:
+The configuration file also stores your selected metadata service and API key.
+You can update these via **Settings → Metadata Services** in the GUI:
 
 ```json
 {
@@ -66,8 +67,11 @@ The configuration file also stores your selected metadata service and API key:
   "metadata_api_key": "YOUR_KEY"
 }
 ```
-These values are updated whenever you use the Tag Fixer's connection dialog.
+These values are updated whenever you save the Metadata Services settings.
 Testing the connection or saving will persist your selections for future runs.
+
+MusicBrainz requests require a valid User-Agent string containing your
+application name, version and contact email.
 
 ## File Overview
 

--- a/config.py
+++ b/config.py
@@ -26,7 +26,10 @@ def load_config():
     """
     try:
         with open(CONFIG_PATH, "r", encoding="utf-8") as f:
-            return json.load(f)
+            cfg = json.load(f)
+        if "musicbrainz_useragent" not in cfg:
+            cfg["musicbrainz_useragent"] = {"app": "", "version": "", "contact": ""}
+        return cfg
     except Exception:
         return {}
 

--- a/main_gui.py
+++ b/main_gui.py
@@ -399,6 +399,12 @@ class SoundVaultImporterApp(tk.Tk):
         file_menu.add_command(label="Exit", command=self.quit)
         menubar.add_cascade(label="File", menu=file_menu)
 
+        settings_menu = tk.Menu(menubar, tearoff=False)
+        settings_menu.add_command(
+            label="Metadata Services…", command=self.open_metadata_settings
+        )
+        menubar.add_cascade(label="Settings", menu=settings_menu)
+
         tools_menu = tk.Menu(menubar, tearoff=False)
         tools_menu.add_command(
             label="Regenerate Playlists", command=self.regenerate_playlists
@@ -2223,6 +2229,19 @@ class SoundVaultImporterApp(tk.Tk):
         self.chat_history.insert("end", f"Assistant: {reply}\n\n")
         self.chat_history.configure(state="disabled")
         self.chat_history.see("end")
+
+    def open_metadata_settings(self):
+        """Open a non-modal window for configuring metadata services."""
+        if getattr(self, "_metadata_win", None) and self._metadata_win.winfo_exists():
+            self._metadata_win.focus()
+            return
+        win = tk.Toplevel(self)
+        win.title("Metadata Services")
+        from plugins.acoustid_plugin import MetadataServiceConfigFrame
+
+        frame = MetadataServiceConfigFrame(win)
+        frame.pack(fill="both", expand=True, padx=10, pady=10)
+        self._metadata_win = win
 
     def _log(self, msg):
         self.output.configure(state="normal")

--- a/plugins/acoustid_plugin.py
+++ b/plugins/acoustid_plugin.py
@@ -1,116 +1,179 @@
-import acoustid
-import musicbrainzngs
-from itertools import islice
+import threading
 import tkinter as tk
-from tkinter import messagebox, ttk
-import importlib
+from tkinter import ttk
+
+import musicbrainzngs
 
 from plugins.base import MetadataPlugin
-from utils.path_helpers import ensure_long_path
-import tag_fixer
-from tag_fixer import (
-    ACOUSTID_APP_NAME,
-    ACOUSTID_APP_VERSION,
-)
-from config import load_config, save_config, SUPPORTED_SERVICES
+from plugins.api_service import ApiService
 from metadata_service import query_metadata
+from config import load_config, save_config, CONFIG_PATH, SUPPORTED_SERVICES
+import tag_fixer
 
-musicbrainzngs.set_useragent(
-    ACOUSTID_APP_NAME,
-    ACOUSTID_APP_VERSION,
-    "youremail@example.com",
-)
 
-class AcoustIDPlugin(MetadataPlugin):
-    @staticmethod
-    def _prompt_reconnect() -> bool:
-        """Prompt for service selection and API key update."""
-        cfg = load_config()
-        root = tk.Tk()
-        root.withdraw()
-        top = tk.Toplevel(root)
-        top.title("Metadata Connection Failed")
+class AcoustIDService(MetadataPlugin, ApiService):
+    """Metadata lookup via the AcoustID web service."""
 
-        services = []
-        for svc in SUPPORTED_SERVICES:
-            if svc == "Spotify" and importlib.util.find_spec("spotipy") is None:
-                continue
-            services.append(svc)
+    def __init__(self):
+        ApiService.__init__(self, CONFIG_PATH)
 
-        tk.Label(top, text="Service:").grid(row=0, column=0, sticky="e", padx=5, pady=5)
-        service_var = tk.StringVar(value=cfg.get("metadata_service", "AcoustID"))
-        ttk.Combobox(top, textvariable=service_var, values=services, state="readonly").grid(row=0, column=1, padx=5, pady=5)
-
-        tk.Label(top, text="API Key:").grid(row=1, column=0, sticky="e", padx=5, pady=5)
-        api_var = tk.StringVar(value=cfg.get("metadata_api_key", tag_fixer.ACOUSTID_API_KEY))
-        ttk.Entry(top, textvariable=api_var, width=40).grid(row=1, column=1, padx=5, pady=5)
-
-        result = {"ok": False}
-
-    def save_current_values() -> None:
-        cfg = load_config()
-        cfg["metadata_service"] = service_var.get()
-        cfg["metadata_api_key"] = api_var.get()
-        save_config(cfg)
-        if service_var.get() == "AcoustID":
-            tag_fixer.ACOUSTID_API_KEY = api_var.get()
-
-    def do_test() -> None:
-        save_current_values()
+    def test_connection(self):
+        import requests
         try:
-            if service_var.get() == "AcoustID":
-                import requests
-                requests.get("https://api.acoustid.org/v2/", timeout=5)
-            else:
-                query_metadata(service_var.get(), api_var.get(), "")
+            requests.get("https://api.acoustid.org/v2/", timeout=5)
+        except Exception as e:
+            return False, str(e)
+        return True, "OK"
+
+    def query(self, fingerprint: str):
+        cfg = load_config()
+        api_key = cfg.get("metadata_api_key", tag_fixer.ACOUSTID_API_KEY)
+        return query_metadata("AcoustID", api_key, fingerprint)
+
+    def identify(self, file_path: str) -> dict:  # for MetadataPlugin
+        try:
+            return self.query(file_path)
         except Exception:
-            messagebox.showerror("Connection", "Connection failed", parent=top)
-        else:
-            messagebox.showinfo("Connection", "Connection success", parent=top)
-
-
-        def do_save() -> None:
-            save_current_values()
-            result["ok"] = True
-            top.destroy()
-
-        ttk.Button(top, text="Test Connection", command=do_test).grid(row=2, column=0, padx=5, pady=5)
-        ttk.Button(top, text="Save", command=do_save).grid(row=2, column=1, padx=5, pady=5)
-
-        top.protocol("WM_DELETE_WINDOW", lambda: (save_current_values(), top.destroy()))
-        top.grab_set()
-        root.wait_window(top)
-        root.destroy()
-        return result["ok"]
-
-    def identify(self, file_path: str) -> dict:
-        while True:
-            cfg = load_config()
-            service = cfg.get("metadata_service", "AcoustID")
-            api_key = cfg.get("metadata_api_key", tag_fixer.ACOUSTID_API_KEY)
-            try:
-                return query_metadata(service, api_key, file_path)
-            except acoustid.NoBackendError:
-                return {}
-            except acoustid.FingerprintGenerationError:
-                return {}
-            except Exception:
-                if not self._prompt_reconnect():
-                    return {}
-                continue
+            return {}
 
     @staticmethod
     def check_connection() -> bool:
-        """Return True if the configured metadata service is reachable."""
+        ok, _ = AcoustIDService().test_connection()
+        return ok
+
+
+class MusicBrainzService(ApiService):
+    """MusicBrainz integration using ``musicbrainzngs``."""
+
+    def __init__(self):
+        ApiService.__init__(self, CONFIG_PATH)
         cfg = load_config()
-        service = cfg.get("metadata_service", "AcoustID")
-        api_key = cfg.get("metadata_api_key", tag_fixer.ACOUSTID_API_KEY)
+        ua = cfg.get("musicbrainz_useragent", {})
+        self.app = ua.get("app", "SoundVault")
+        self.version = ua.get("version", "1.0")
+        self.contact = ua.get("contact", "")
+
+    def test_connection(self):
+        from musicbrainzngs import MusicBrainzError
+
         try:
-            if service == "AcoustID":
-                import requests
-                requests.get("https://api.acoustid.org/v2/", timeout=5)
-            else:
-                query_metadata(service, api_key, "")
-        except Exception:
-            return AcoustIDPlugin._prompt_reconnect()
-        return True
+            musicbrainzngs.set_useragent(self.app, self.version, self.contact)
+            res = musicbrainzngs.search_artists(query="Beatles", limit=1)
+            n = len(res.get("artist-list", []))
+            return True, f"OK – found {n} artist(s)"
+        except MusicBrainzError as e:
+            return False, str(e)
+        except Exception as e:
+            return False, str(e)
+
+    def query(self, fingerprint: str):
+        musicbrainzngs.set_useragent(self.app, self.version, self.contact)
+        return query_metadata("MusicBrainz", self.contact, fingerprint)
+
+
+class MetadataServiceConfigFrame(tk.Frame):
+    """Reusable configuration UI for metadata services."""
+
+    def __init__(self, master: tk.Misc):
+        super().__init__(master)
+        self.cfg = load_config()
+        self.service_var = tk.StringVar(value=self.cfg.get("metadata_service", "AcoustID"))
+        self.api_var = tk.StringVar(value=self.cfg.get("metadata_api_key", tag_fixer.ACOUSTID_API_KEY))
+        ua = self.cfg.get("musicbrainz_useragent", {})
+        self.mb_app_var = tk.StringVar(value=ua.get("app", ""))
+        self.mb_ver_var = tk.StringVar(value=ua.get("version", ""))
+        self.mb_contact_var = tk.StringVar(value=ua.get("contact", ""))
+        self.status_var = tk.StringVar()
+        self.last_ok = False
+
+        services = [s for s in SUPPORTED_SERVICES if s in ("AcoustID", "MusicBrainz")]
+        tk.Label(self, text="Service:").grid(row=0, column=0, sticky="e", padx=5, pady=5)
+        self.service_box = ttk.Combobox(self, textvariable=self.service_var, values=services, state="readonly")
+        self.service_box.grid(row=0, column=1, sticky="w", padx=5, pady=5)
+        self.service_box.bind("<<ComboboxSelected>>", lambda _e: self._update_visible())
+
+        self.api_lbl = tk.Label(self, text="API Key:")
+        self.api_entry = ttk.Entry(self, textvariable=self.api_var, width=40)
+
+        self.mb_frame = ttk.Frame(self)
+        ttk.Label(self.mb_frame, text="App:").grid(row=0, column=0, sticky="e", padx=5, pady=2)
+        ttk.Entry(self.mb_frame, textvariable=self.mb_app_var, width=30).grid(row=0, column=1, sticky="w", padx=5, pady=2)
+        ttk.Label(self.mb_frame, text="Version:").grid(row=1, column=0, sticky="e", padx=5, pady=2)
+        ttk.Entry(self.mb_frame, textvariable=self.mb_ver_var, width=20).grid(row=1, column=1, sticky="w", padx=5, pady=2)
+        ttk.Label(self.mb_frame, text="Contact:").grid(row=2, column=0, sticky="e", padx=5, pady=2)
+        ttk.Entry(self.mb_frame, textvariable=self.mb_contact_var, width=40).grid(row=2, column=1, sticky="w", padx=5, pady=2)
+
+        self.test_btn = ttk.Button(self, text="Test Connection", command=self._on_test)
+        self.status_lbl = ttk.Label(self, textvariable=self.status_var)
+        self.save_btn = ttk.Button(self, text="Save", command=self._on_save, state="disabled")
+
+        self.inputs = [self.service_box, self.api_entry, self.mb_frame]
+        self._update_visible()
+
+    def _set_state(self, state: str) -> None:
+        for w in self.inputs:
+            w_state = getattr(w, "state", None)
+            try:
+                if isinstance(w, ttk.Frame):
+                    for child in w.winfo_children():
+                        child.configure(state=state)
+                else:
+                    w.configure(state=state)
+            except Exception:
+                pass
+
+    def _save_values(self) -> None:
+        cfg = load_config()
+        cfg["metadata_service"] = self.service_var.get()
+        cfg["metadata_api_key"] = self.api_var.get()
+        cfg["musicbrainz_useragent"] = {
+            "app": self.mb_app_var.get(),
+            "version": self.mb_ver_var.get(),
+            "contact": self.mb_contact_var.get(),
+        }
+        save_config(cfg)
+
+    def _on_test(self) -> None:
+        self._save_values()
+        self._set_state("disabled")
+        self.status_var.set("Testing…")
+
+        if self.service_var.get() == "MusicBrainz":
+            service = MusicBrainzService()
+        else:
+            service = AcoustIDService()
+
+        def worker() -> None:
+            ok, msg = service.test_connection()
+            def done() -> None:
+                self.last_ok = ok
+                self.status_var.set(msg)
+                self.status_lbl.configure(foreground="green" if ok else "red")
+                self._set_state("normal")
+                self.save_btn.configure(state="normal" if ok else "disabled")
+            self.after(0, done)
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _on_save(self) -> None:
+        self._save_values()
+        self.last_ok = False
+        self.save_btn.configure(state="disabled")
+
+    def _update_visible(self) -> None:
+        svc = self.service_var.get()
+        row = 1
+        if svc == "AcoustID":
+            self.mb_frame.grid_forget()
+            self.api_lbl.grid(row=row, column=0, sticky="e", padx=5, pady=5)
+            self.api_entry.grid(row=row, column=1, sticky="w", padx=5, pady=5)
+            row += 1
+        else:
+            self.api_lbl.grid_forget()
+            self.api_entry.grid_forget()
+            self.mb_frame.grid(row=row, column=0, columnspan=2, sticky="w", pady=5)
+            row += 1
+        self.test_btn.grid(row=row, column=0, sticky="w", padx=5, pady=5)
+        self.status_lbl.grid(row=row, column=1, sticky="w", padx=5, pady=5)
+        self.save_btn.grid(row=row + 1, column=1, sticky="e", padx=5, pady=5)
+        self.save_btn.configure(state="normal" if self.last_ok else "disabled")

--- a/plugins/api_service.py
+++ b/plugins/api_service.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict, Tuple
+
+
+class ApiService(ABC):
+    """Abstract base class for external metadata services."""
+
+    def __init__(self, config_path: str) -> None:
+        self.config_path = config_path
+
+    @abstractmethod
+    def test_connection(self) -> Tuple[bool, str]:
+        """Return a tuple ``(success, message)`` after checking connectivity."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def query(self, fingerprint: str) -> Dict:
+        """Query the service using ``fingerprint`` and return metadata."""
+        raise NotImplementedError

--- a/tests/test_musicbrainz_service.py
+++ b/tests/test_musicbrainz_service.py
@@ -1,0 +1,35 @@
+import sys
+import types
+import importlib
+
+
+def test_musicbrainz_service_success(monkeypatch):
+    mb = types.ModuleType('musicbrainzngs')
+    mb.set_useragent = lambda *a, **k: None
+    mb.search_artists = lambda **kw: {'artist-list': [1]}
+    mb.MusicBrainzError = Exception
+    monkeypatch.setitem(sys.modules, 'musicbrainzngs', mb)
+    import plugins.acoustid_plugin as ap
+    importlib.reload(ap)
+    svc = ap.MusicBrainzService()
+    ok, msg = svc.test_connection()
+    assert ok is True
+    assert 'artist' in msg
+
+
+def test_musicbrainz_service_error(monkeypatch):
+    class Err(Exception):
+        pass
+    mb = types.ModuleType('musicbrainzngs')
+    mb.set_useragent = lambda *a, **k: None
+    def fail(**kw):
+        raise Err('fail')
+    mb.search_artists = fail
+    mb.MusicBrainzError = Err
+    monkeypatch.setitem(sys.modules, 'musicbrainzngs', mb)
+    import plugins.acoustid_plugin as ap
+    importlib.reload(ap)
+    svc = ap.MusicBrainzService()
+    ok, msg = svc.test_connection()
+    assert ok is False
+    assert 'fail' in msg


### PR DESCRIPTION
## Summary
- add `ApiService` abstract base
- implement `AcoustIDService` and new `MusicBrainzService`
- provide `MetadataServiceConfigFrame` UI
- hook settings window into main menu
- persist new `musicbrainz_useragent` in config
- document the new settings page and MusicBrainz user-agent requirement
- test connection logic for MusicBrainz service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d18e79a3c83208e17b5009ff8775f