### PR TITLE
Async comparison table and progress callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Cluster generation writes progress into `<method>_log.txt` inside your library s
 
 The indexer automatically prefixes file paths with `\\?\` on Windows, allowing it to work with directories deeper than the classic 260-character limit.
 
+## Threading
+
+Long running actions such as indexing, tag fixing and tidal-dl comparison are executed in daemon threads. GUI updates from these background tasks are scheduled using Tkinter's `after` method so message boxes and progress indicators always run on the main thread.
+
 ## Configuration
 
 User settings are stored in `~/.soundvault_config.json`. To tweak the fuzzy fingerprint

--- a/tidal_sync.py
+++ b/tidal_sync.py
@@ -347,6 +347,7 @@ def match_downloads(
     downloads: List[Dict[str, str]],
     threshold: float = 0.3,
     log_callback: Callable[[str], None] | None = None,
+    progress_callback: Callable[[int], None] | None = None,
 ) -> List[Dict[str, object]]:
     """Match subpar tracks with potential replacements in downloads."""
     matches: List[Dict[str, object]] = []
@@ -375,8 +376,10 @@ def match_downloads(
 
     if log_callback is None:
         log_callback = lambda msg: None
+    if progress_callback is None:
+        progress_callback = lambda idx: None
 
-    for sp in subpar:
+    for idx, sp in enumerate(subpar, start=1):
         key_exact = (
             (sp.get("artist") or "").lower(),
             (sp.get("title") or "").lower(),
@@ -483,6 +486,8 @@ def match_downloads(
                 "note": note,
             }
         )
+        if progress_callback:
+            progress_callback(idx)
     return matches
 
 


### PR DESCRIPTION
## Summary
- spawn a daemon thread for building the comparison table
- add `progress_callback` option to `match_downloads`
- update GUI progress with `self.after` and show errors on the main thread
- describe threading model in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d406416408320972bf5f3637c0571