### PR TITLE
Add candidate match listing for ambiguous downloads

### DIFF
--- a/candidate_popup.py
+++ b/candidate_popup.py
@@ -1,0 +1,33 @@
+import os
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+from controllers.highlight_controller import play_snippet, PYDUB_AVAILABLE
+
+class CandidatePopup(tk.Toplevel):
+    """Popup showing alternative candidate files with play buttons."""
+
+    def __init__(self, parent: tk.Misc, candidates: list[str]):
+        super().__init__(parent)
+        self.title("Candidate Matches")
+        self.resizable(False, False)
+        self.transient(parent)
+
+        frame = ttk.Frame(self)
+        frame.pack(padx=10, pady=10, fill="both", expand=True)
+
+        for path in candidates:
+            row = ttk.Frame(frame)
+            ttk.Label(row, text=os.path.basename(path)).pack(side="left", padx=(0, 5))
+            if PYDUB_AVAILABLE:
+                ttk.Button(row, text="Play", command=lambda p=path: self._play(p)).pack(side="right")
+            row.pack(fill="x", pady=2)
+
+        ttk.Button(self, text="Close", command=self.destroy).pack(pady=(0, 10))
+
+    def _play(self, path: str) -> None:
+        try:
+            play_snippet(path)
+        except Exception as e:
+            messagebox.showerror("Playback failed", str(e))
+

--- a/tests/test_tidal_sync.py
+++ b/tests/test_tidal_sync.py
@@ -84,6 +84,7 @@ def test_match_downloads_prefix_lookup(monkeypatch):
     ]
     matches = ts.match_downloads(subpar, downloads, threshold=0.1)
     assert matches[0]["download"] == "good.flac"
+    assert matches[0]["candidates"] == []
 
 
 def test_load_subpar_list_fingerprint(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- extend `_find_best_fp_match` to optionally return close candidates
- include candidate list in `match_downloads` results
- add `CandidatePopup` dialog to view and play alternative matches
- display a "Options" column in the GUI match table with double‑click popup
- adjust tests for new return format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4343580c83209fde1aa12e598c06