### PR TITLE
Add per-format fingerprint thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ threshold used during deduplication, add a value like:
 
 Lower values require more similar fingerprints.
 
+Per-format fingerprint thresholds used by the tidal-dl matcher can also be
+configured. Add a `format_fp_thresholds` section with extension keys:
+
+```json
+{
+  "format_fp_thresholds": {
+    "default": 0.3,
+    ".flac": 0.3,
+    ".mp3": 0.2,
+    ".aac": 0.25
+  }
+}
+```
+
+Values are floating point distances – lower numbers require closer matches.
+
 The configuration file also stores your selected metadata service and API key.
 You can update these via **Settings → Metadata Services** in the GUI:
 

--- a/config.py
+++ b/config.py
@@ -18,6 +18,15 @@ NEAR_DUPLICATE_THRESHOLD = 0.1
 # File format quality priority used during Library Sync
 FORMAT_PRIORITY = {".flac": 3, ".wav": 2, ".mp3": 1}
 
+# Default fingerprint matching thresholds by file extension. The ``default`` key
+# is used when a specific extension is not provided.
+DEFAULT_FP_THRESHOLDS = {
+    "default": 0.3,
+    ".flac": 0.3,
+    ".mp3": 0.3,
+    ".aac": 0.3,
+}
+
 
 def load_config():
     """Load configuration from ``CONFIG_PATH``.
@@ -28,7 +37,13 @@ def load_config():
         with open(CONFIG_PATH, "r", encoding="utf-8") as f:
             cfg = json.load(f)
         if "musicbrainz_useragent" not in cfg:
-            cfg["musicbrainz_useragent"] = {"app": "", "version": "", "contact": ""}
+            cfg["musicbrainz_useragent"] = {
+                "app": "",
+                "version": "",
+                "contact": "",
+            }
+        if "format_fp_thresholds" not in cfg:
+            cfg["format_fp_thresholds"] = DEFAULT_FP_THRESHOLDS.copy()
         return cfg
     except Exception:
         return {}

--- a/tests/test_tidal_sync.py
+++ b/tests/test_tidal_sync.py
@@ -82,9 +82,79 @@ def test_match_downloads_prefix_lookup(monkeypatch):
             "fp_prefix": "1 2 3 4 5"[: ts.FP_PREFIX_LEN],
         }
     ]
-    matches = ts.match_downloads(subpar, downloads, threshold=0.1)
+    matches = ts.match_downloads(subpar, downloads, thresholds={"default": 0.1})
     assert matches[0]["download"] == "good.flac"
     assert matches[0]["candidates"] == []
+
+
+def test_match_downloads_extension_threshold(monkeypatch):
+    ts = load_module(monkeypatch)
+    downloads = [
+        {
+            "artist": "A",
+            "title": "T",
+            "album": "AL",
+            "path": "good.flac",
+            "fingerprint": "1 2 3 4 6",
+            "fp_prefix": "1 2 3 4 6"[: ts.FP_PREFIX_LEN],
+        },
+        {
+            "artist": "A",
+            "title": "T",
+            "album": "AL",
+            "path": "bad.mp3",
+            "fingerprint": "1 2 3 4 6",
+            "fp_prefix": "1 2 3 4 6"[: ts.FP_PREFIX_LEN],
+        },
+    ]
+    subpar = [
+        {
+            "artist": "A",
+            "title": "T",
+            "album": "AL",
+            "path": "orig.mp3",
+            "fingerprint": "1 2 3 4 5",
+            "fp_prefix": "1 2 3 4 5"[: ts.FP_PREFIX_LEN],
+        }
+    ]
+    thresholds = {"default": 0.5, ".mp3": 0.1, ".flac": 0.5}
+    matches = ts.match_downloads(subpar, downloads, thresholds=thresholds)
+    assert matches[0]["download"] == "good.flac"
+
+
+def test_match_downloads_mp3_override(monkeypatch):
+    ts = load_module(monkeypatch)
+    downloads = [
+        {
+            "artist": "A",
+            "title": "T",
+            "album": "AL",
+            "path": "good.mp3",
+            "fingerprint": "1 2 3 4 6",
+            "fp_prefix": "1 2 3 4 6"[: ts.FP_PREFIX_LEN],
+        },
+        {
+            "artist": "A",
+            "title": "T",
+            "album": "AL",
+            "path": "bad.flac",
+            "fingerprint": "1 2 3 4 6",
+            "fp_prefix": "1 2 3 4 6"[: ts.FP_PREFIX_LEN],
+        },
+    ]
+    subpar = [
+        {
+            "artist": "A",
+            "title": "T",
+            "album": "AL",
+            "path": "orig.mp3",
+            "fingerprint": "1 2 3 4 5",
+            "fp_prefix": "1 2 3 4 5"[: ts.FP_PREFIX_LEN],
+        }
+    ]
+    thresholds = {"default": 0.1, ".mp3": 0.3, ".flac": 0.1}
+    matches = ts.match_downloads(subpar, downloads, thresholds=thresholds)
+    assert matches[0]["download"] == "good.mp3"
 
 
 def test_load_subpar_list_fingerprint(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- support configurable fingerprint thresholds by audio format
- expose new options in GUI and persist to config
- adjust tidal sync matching to use per-extension thresholds
- document new configuration settings
- test threshold selection logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d49fcd71c83208f781f0fbd17d28d