### PR TITLE
Add result callback and queue processing for tidal sync

### DIFF
--- a/tests/test_tidal_sync.py
+++ b/tests/test_tidal_sync.py
@@ -82,9 +82,16 @@ def test_match_downloads_prefix_lookup(monkeypatch):
             "fp_prefix": "1 2 3 4 5"[: ts.FP_PREFIX_LEN],
         }
     ]
-    matches = ts.match_downloads(subpar, downloads, thresholds={"default": 0.1})
+    received = []
+    matches = ts.match_downloads(
+        subpar,
+        downloads,
+        thresholds={"default": 0.1},
+        result_callback=received.append,
+    )
     assert matches[0]["download"] == "good.flac"
     assert matches[0]["candidates"] == []
+    assert received == matches
 
 
 def test_match_downloads_extension_threshold(monkeypatch):

--- a/tidal_sync.py
+++ b/tidal_sync.py
@@ -426,6 +426,7 @@ def match_downloads(
     thresholds: Dict[str, float] | None = None,
     log_callback: Callable[[str], None] | None = None,
     progress_callback: Callable[[int], None] | None = None,
+    result_callback: Callable[[Dict[str, object]], None] | None = None,
 ) -> List[Dict[str, object]]:
     """Match subpar tracks with potential replacements in downloads."""
     if thresholds is None:
@@ -565,17 +566,18 @@ def match_downloads(
             f"DEBUG: Best match: {best['path'] if best else None} with score={score if score is not None else float('nan'):.4f}",
             log_callback,
         )
-        matches.append(
-            {
-                "original": sp["path"],
-                "download": None if best is None else best["path"],
-                "score": score,
-                "method": method,
-                "tags": sp,
-                "note": note,
-                "candidates": cand_paths,
-            }
-        )
+        match = {
+            "original": sp["path"],
+            "download": None if best is None else best["path"],
+            "score": score,
+            "method": method,
+            "tags": sp,
+            "note": note,
+            "candidates": cand_paths,
+        }
+        matches.append(match)
+        if result_callback:
+            result_callback(match)
         if progress_callback:
             progress_callback(idx)
     return matches


### PR DESCRIPTION
## Summary
- extend `tidal_sync.match_downloads` with a `result_callback` parameter
- stream match results through a queue in the GUI
- poll the queue to incrementally render the comparison table
- test that result callbacks receive each match

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d5981f3a4832092849a3ab5bd3148