### PR TITLE
Add audio fingerprint normalization

### DIFF
--- a/audio_norm.py
+++ b/audio_norm.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import io
+from typing import Callable
+
+from pydub import AudioSegment, silence
+
+
+SILENCE_THRESH = -50  # dBFS used for silence detection
+
+
+def normalize_for_fp(
+    path: str,
+    fingerprint_offset_ms: int = 0,
+    fingerprint_duration_ms: int = 120_000,
+    allow_mismatched_edits: bool = True,
+    log_callback: Callable[[str], None] | None = None,
+) -> io.BytesIO:
+    """Return normalized audio segment for fingerprinting as a BytesIO buffer."""
+    audio = AudioSegment.from_file(path)
+    audio = audio.set_frame_rate(44100).set_channels(2)
+
+    lead = silence.detect_leading_silence(audio, silence_thresh=SILENCE_THRESH)
+    trim_lead = 0
+    if lead > 100:
+        trim_lead = min(lead - 100, 500)
+    trail = 0
+    end_sil = silence.detect_silence(audio, min_silence_len=50, silence_thresh=SILENCE_THRESH)
+    if end_sil:
+        last_start, last_end = end_sil[-1]
+        if last_end >= len(audio):
+            trail = len(audio) - last_start
+    trim_trail = 0
+    if trail > 100:
+        trim_trail = min(trail - 100, 500)
+
+    if trim_lead or trim_trail:
+        audio = audio[trim_lead: len(audio) - trim_trail]
+
+    trimmed_len = len(audio)
+    if abs(trimmed_len - fingerprint_duration_ms) > 5000:
+        if log_callback:
+            log_callback(
+                f"WARNING: trimmed duration {trimmed_len}ms differs from target {fingerprint_duration_ms}ms"
+            )
+        if not allow_mismatched_edits:
+            raise ValueError("Mismatched edit length")
+
+    start = fingerprint_offset_ms
+    segment = audio[start:start + fingerprint_duration_ms]
+    if len(segment) < fingerprint_duration_ms:
+        segment += AudioSegment.silent(duration=fingerprint_duration_ms - len(segment))
+
+    buf = io.BytesIO()
+    segment.export(buf, format="wav")
+    buf.seek(0)
+    return buf

--- a/config.py
+++ b/config.py
@@ -27,6 +27,11 @@ DEFAULT_FP_THRESHOLDS = {
     ".aac": 0.3,
 }
 
+# Default settings for fingerprint normalization
+FP_OFFSET_MS = 0
+FP_DURATION_MS = 120_000
+ALLOW_MISMATCHED_EDITS = True
+
 
 def load_config():
     """Load configuration from ``CONFIG_PATH``.
@@ -44,9 +49,16 @@ def load_config():
             }
         if "format_fp_thresholds" not in cfg:
             cfg["format_fp_thresholds"] = DEFAULT_FP_THRESHOLDS.copy()
+        cfg.setdefault("fingerprint_offset_ms", FP_OFFSET_MS)
+        cfg.setdefault("fingerprint_duration_ms", FP_DURATION_MS)
+        cfg.setdefault("allow_mismatched_edits", ALLOW_MISMATCHED_EDITS)
         return cfg
     except Exception:
-        return {}
+        return {
+            "fingerprint_offset_ms": FP_OFFSET_MS,
+            "fingerprint_duration_ms": FP_DURATION_MS,
+            "allow_mismatched_edits": ALLOW_MISMATCHED_EDITS,
+        }
 
 
 def save_config(cfg: dict) -> None:

--- a/tests/test_fingerprint_norm.py
+++ b/tests/test_fingerprint_norm.py
@@ -1,0 +1,84 @@
+import io
+import types
+import sys
+import importlib
+from pydub import AudioSegment
+from pydub.generators import Sine
+
+
+def setup_acoustid(monkeypatch):
+    acoustid_stub = types.ModuleType('acoustid')
+    def fake_fp(fileobj=None, path=None):
+        if fileobj is None:
+            fileobj = open(path, 'rb')
+        data = fileobj.read()
+        return 0, str(hash(data))
+    acoustid_stub.fingerprint_file = fake_fp
+    monkeypatch.setitem(sys.modules, 'acoustid', acoustid_stub)
+
+
+class DummyLogger:
+    def __init__(self):
+        self.msgs = []
+
+    def __call__(self, msg):
+        self.msgs.append(msg)
+
+
+def test_trim_leading_silence(tmp_path, monkeypatch):
+    setup_acoustid(monkeypatch)
+    import audio_norm
+    tone = Sine(440).to_audio_segment(duration=1700)
+    audio = AudioSegment.silent(duration=300) + tone
+    path = tmp_path / "s.wav"
+    audio.export(path, format="wav")
+    buf = audio_norm.normalize_for_fp(str(path), fingerprint_duration_ms=2000)
+    seg = AudioSegment.from_file(buf)
+    lead = audio_norm.silence.detect_leading_silence(seg, silence_thresh=audio_norm.SILENCE_THRESH)
+    assert lead <= 100
+
+
+def test_format_independence(tmp_path, monkeypatch):
+    setup_acoustid(monkeypatch)
+    import audio_norm
+    tone = Sine(440).to_audio_segment(duration=1000)
+    a1 = tone.set_frame_rate(48000).set_channels(1)
+    a2 = tone.set_frame_rate(44100).set_channels(2)
+    p1 = tmp_path / "a1.wav"
+    p2 = tmp_path / "a2.wav"
+    a1.export(p1, format="wav")
+    a2.export(p2, format="wav")
+    buf1 = audio_norm.normalize_for_fp(str(p1), fingerprint_duration_ms=1000)
+    buf2 = audio_norm.normalize_for_fp(str(p2), fingerprint_duration_ms=1000)
+    import acoustid
+    _, fp1 = acoustid.fingerprint_file(fileobj=buf1)
+    _, fp2 = acoustid.fingerprint_file(fileobj=buf2)
+    assert fp1 == fp2
+
+
+def test_radio_edit_alignment(tmp_path, monkeypatch):
+    setup_acoustid(monkeypatch)
+    import audio_norm
+    tone = Sine(440).to_audio_segment(duration=8000)
+    long = tone
+    short = tone[:5000]
+    p1 = tmp_path / "long.wav"
+    p2 = tmp_path / "short.wav"
+    long.export(p1, format="wav")
+    short.export(p2, format="wav")
+    log = DummyLogger()
+    audio_norm.normalize_for_fp(str(p1), fingerprint_duration_ms=5000, log_callback=log)
+    audio_norm.normalize_for_fp(str(p2), fingerprint_duration_ms=5000, log_callback=log)
+    assert any("WARNING" in m for m in log.msgs)
+
+
+def test_padding_short_track(tmp_path, monkeypatch):
+    setup_acoustid(monkeypatch)
+    import audio_norm
+    tone = Sine(440).to_audio_segment(duration=500)
+    p = tmp_path / "s.wav"
+    tone.export(p, format="wav")
+    buf = audio_norm.normalize_for_fp(str(p), fingerprint_duration_ms=1000)
+    seg = AudioSegment.from_file(buf)
+    assert len(seg) == 1000
+

--- a/tidal_sync.py
+++ b/tidal_sync.py
@@ -324,8 +324,17 @@ def _scan_one(path: str, log_callback: Callable[[str], None] | None = None) -> D
 
 
 def _fingerprint(path: str, log_callback: Callable[[str], None] | None = None) -> str | None:
+    from config import load_config
+    from audio_norm import normalize_for_fp
+
+    cfg = load_config()
+    offset = cfg.get("fingerprint_offset_ms", 0)
+    duration = cfg.get("fingerprint_duration_ms", 120_000)
+    allow = cfg.get("allow_mismatched_edits", True)
+
     try:
-        _, fp = acoustid.fingerprint_file(path)
+        buf = normalize_for_fp(path, offset, duration, allow, log_callback)
+        _, fp = acoustid.fingerprint_file(fileobj=buf)
         _dlog(
             f"DEBUG: Fingerprinting file: {path}; fp prefix={fp[:FP_PREFIX_LEN]!r}",
             log_callback,


### PR DESCRIPTION
## Summary
- implement `normalize_for_fp` for audio normalization
- add default config settings for fingerprint normalization
- call normalization in `tidal_sync._fingerprint`
- add unit tests for normalization logic

## Testing
- `pytest -q` *(fails: No module named 'pydub')*

------
https://chatgpt.com/codex/tasks/task_e_687d5cc1ecb48320b72a96b113ae737b