### PR TITLE
Log fingerprinting failures

### DIFF
--- a/tidal_sync.py
+++ b/tidal_sync.py
@@ -368,7 +368,10 @@ def _fingerprint(path: str, log_callback: Callable[[str], None] | None = None) -
             log_callback,
         )
         return fp
-    except Exception:
+    except Exception as exc:
+        msg = f"Failed to fingerprint {path}: {exc}"
+        _dlog(f"ERROR: {msg}", log_callback)
+        logging.error(msg)
         return None
 
 


### PR DESCRIPTION
## Summary
- surface fingerprinting errors instead of quietly returning `None`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydub')*

------
https://chatgpt.com/codex/tasks/task_e_687ec652b14c8320ac10644ea4a7a7d8