### PR TITLE
Add configurable thresholds to library sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ configured. Add a `format_fp_thresholds` section with extension keys:
 
 Values are floating point distances – lower numbers require closer matches.
 
+The same dictionary can be provided to ``library_sync.compare_libraries`` via
+the optional ``thresholds`` parameter to control how strictly fingerprints are
+matched when scanning two libraries.
+
 You can also store the path to your library for automatic scanning:
 
 ```json

--- a/main_gui.py
+++ b/main_gui.py
@@ -66,7 +66,7 @@ from controllers.normalize_controller import (
 )
 from plugins.assistant_plugin import AssistantPlugin
 from controllers.cluster_controller import cluster_library
-from config import load_config, save_config
+from config import load_config, save_config, DEFAULT_FP_THRESHOLDS
 
 FilterFn = Callable[[FileRecord], bool]
 _cached_filters = None
@@ -2367,10 +2367,14 @@ class SoundVaultImporterApp(tk.Tk):
             messagebox.showwarning("Scan", "Please choose library and incoming folders.")
             return
         db = os.path.join(lib, "Docs", ".soundvault.db")
+        cfg = load_config()
+        thresholds = cfg.get("format_fp_thresholds", DEFAULT_FP_THRESHOLDS)
 
         def task():
             try:
-                res = library_sync.compare_libraries(lib, inc, db)
+                res = library_sync.compare_libraries(
+                    lib, inc, db, thresholds=thresholds
+                )
                 self.sync_new = res["new"]
                 self.sync_existing = res["existing"]
                 self.sync_improved = res["improved"]

--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -70,6 +70,26 @@ def test_compare_libraries(tmp_path):
     flush_cache(str(db))
 
 
+def test_compare_libraries_thresholds(tmp_path):
+    lib = tmp_path / 'lib'
+    inc = tmp_path / 'inc'
+    lib.mkdir()
+    inc.mkdir()
+    (lib / 'a.flac').write_text('x')
+    (inc / 'a.flac').write_text('x')
+
+    db = tmp_path / 'fp.db'
+    res = compare_libraries(
+        str(lib),
+        str(inc),
+        str(db),
+        thresholds={"default": 0.0},
+    )
+
+    assert str(inc / 'a.flac') in set(res['new'])
+    flush_cache(str(db))
+
+
 def test_copy_and_replace(tmp_path):
     lib = tmp_path / 'lib'
     inc = tmp_path / 'inc'


### PR DESCRIPTION
## Summary
- support per-format fingerprint thresholds in `library_sync.compare_libraries`
- wire up the GUI to pass configured thresholds
- document the new option in the README
- test dictionary thresholds with an extra unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydub')*

------
https://chatgpt.com/codex/tasks/task_e_687ec74f3e488320a676106904d0f1e8