### PR TITLE
Add cross-format fingerprint comparison test

### DIFF
--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -110,3 +110,41 @@ def test_copy_and_replace(tmp_path):
     backup = lib / '__backup__' / 'old.mp3'
     assert backup.exists()
     assert f_old.read_text() == 'better'
+
+
+def test_format_threshold_match(tmp_path, monkeypatch):
+    lib = tmp_path / "lib"
+    inc = tmp_path / "inc"
+    lib.mkdir()
+    inc.mkdir()
+
+    def make_wav(path):
+        import wave
+        with wave.open(str(path), "wb") as w:
+            w.setnchannels(1)
+            w.setsampwidth(2)
+            w.setframerate(44100)
+            w.writeframes(b"\x00\x00" * 44100)
+
+    mp3_file = lib / "song.mp3"
+    wav_file = inc / "song.wav"
+    make_wav(mp3_file)
+    make_wav(wav_file)
+
+    def fake_fp(path):
+        if path.endswith(".wav"):
+            return 0, "1 2 3 4"
+        return 0, "1 2 3 5"
+
+    monkeypatch.setattr(sys.modules["acoustid"], "fingerprint_file", fake_fp)
+
+    db = tmp_path / "fp.db"
+    res = compare_libraries(
+        str(lib),
+        str(inc),
+        str(db),
+        thresholds={".wav": 0.5, ".mp3": 0.5},
+    )
+
+    assert (str(wav_file), str(mp3_file)) in set(res["improved"])
+    flush_cache(str(db))


### PR DESCRIPTION
## Summary
- exercise compare_libraries with wav vs mp3 files
- ensure close fingerprints are matched when using relaxed thresholds

## Testing
- `pytest tests/test_library_sync.py::test_format_threshold_match -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydub')*

------
https://chatgpt.com/codex/tasks/task_e_687ec90904248320ab221b4f38206aaa