### PR TITLE
Add library duplicate finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ python main_gui.py
 4. **Generate Playlists** from your folder structure
 5. **Clustered Playlists** (interactive K-Means/HDBSCAN) via the Tools ▸ Clustered Playlists menu
 6. **Tidal-dl Sync** can upgrade low-quality files to FLAC
-7. Use the **Theme** dropdown and **Help** tab for assistance
+7. **Library Duplicate Scan** finds duplicate tracks after you drop new songs directly into your library
+8. Use the **Theme** dropdown and **Help** tab for assistance
 
 Cluster generation writes progress into `<method>_log.txt` inside your library so you can review the steps later.
 

--- a/docs/project_documentation.html
+++ b/docs/project_documentation.html
@@ -578,6 +578,9 @@ if __name__ == "__main__":
 <h3>2.6 Tidal-dl Sync (<code>tidal_sync.py</code>)</h3>
 <p>Matches your library against tidal-dl downloads and replaces low-quality files
 with their FLAC counterparts. Debug logs can be written for troubleshooting.</p>
+<p>The module also provides <code>find_library_duplicates()</code> which runs the
+indexer's deduplication pass on your library. Place any new songs directly in
+the library and call this helper to list duplicate pairs chosen by quality.</p>
 
 <hr>
 <h3>2.7 Normalize Genres (<code>normalize_controller.py</code>)</h3>

--- a/tidal_sync.py
+++ b/tidal_sync.py
@@ -457,6 +457,22 @@ def _find_best_fp_match(
     )
 
 
+def find_library_duplicates(
+    library_root: str, log_callback: Callable[[str], None] | None = None
+) -> List[Tuple[str, str]]:
+    """Return duplicate track pairs detected within ``library_root``.
+
+    New songs should be placed directly inside the library before running so
+    the indexer's dedupe logic can compare everything at once. The returned
+    list contains ``(original_path, duplicate_path)`` pairs as determined by
+    :func:`music_indexer_api.find_duplicates` which prefers higher quality
+    formats when choosing the file to keep.
+    """
+    from music_indexer_api import find_duplicates as _find
+
+    return _find(library_root, log_callback)
+
+
 def match_downloads(
     subpar: List[Dict[str, str]],
     downloads: List[Dict[str, str]],


### PR DESCRIPTION
## Summary
- add `find_library_duplicates` helper to `tidal_sync.py`
- document duplicate scan workflow in README
- mention new helper in project documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ed96ea63083208a306c9e4b27d9ba