### PR TITLE
Implement cross-album duplicate scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ python main_gui.py
 5. **Clustered Playlists** (interactive K-Means/HDBSCAN) via the Tools ▸ Clustered Playlists menu
 6. **Tidal-dl Sync** can upgrade low-quality files to FLAC
 7. **Library Duplicate Scan** finds duplicate tracks after you drop new songs directly into your library
-8. Use the **Theme** dropdown and **Help** tab for assistance
+8. **Cross-Album Scan** optionally finds duplicates appearing on multiple albums
+9. Use the **Theme** dropdown and **Help** tab for assistance
 
 Cluster generation writes progress into `<method>_log.txt` inside your library so you can review the steps later.
 

--- a/music_indexer_api.py
+++ b/music_indexer_api.py
@@ -762,16 +762,8 @@ def build_dry_run_html(
         lines.append("</pre>")
         return "\n".join(lines)
 
-    def build_cross_album_section() -> str:
-        if not enable_phase_c:
-            return ""
-        return "<h2>Phase C – Cross-Album</h2>"
-
     sec_a = build_exact_metadata_section()
     coord.set_html_section('A', sec_a)
-    sec_c = build_cross_album_section()
-    if sec_c:
-        coord.set_html_section('C', sec_c)
 
     html_body = coord.assemble_final_report()
 

--- a/tests/test_cross_album.py
+++ b/tests/test_cross_album.py
@@ -1,0 +1,26 @@
+import types
+import sys
+
+mutagen_stub = types.ModuleType('mutagen')
+mutagen_stub.File = lambda *a, **k: None
+id3_stub = types.ModuleType('id3')
+id3_stub.ID3NoHeaderError = Exception
+mutagen_stub.id3 = id3_stub
+sys.modules['mutagen'] = mutagen_stub
+sys.modules['mutagen.id3'] = id3_stub
+
+from dry_run_coordinator import DryRunCoordinator
+from near_duplicate_detector import find_near_duplicates
+
+
+def test_cross_album_clusters_and_html():
+    infos = {
+        'a1': {'fp': '1 2', 'album': 'A', 'title': 'Song', 'primary': 'a', 'meta_count': 1},
+        'b1': {'fp': '1 2', 'album': 'B', 'title': 'Song', 'primary': 'a', 'meta_count': 1},
+        'c1': {'fp': '3 4', 'album': 'C', 'title': 'Song', 'primary': 'a', 'meta_count': 1},
+    }
+    coord = DryRunCoordinator()
+    find_near_duplicates(infos, {'.mp3': 0}, 1.0, enable_cross_album=True, coord=coord)
+    clusters = [set(c) for c in coord.near_dupe_clusters]
+    assert any({'a1', 'b1'} <= c for c in clusters)
+    assert 'Phase C – Cross-Album Near-Duplicates' in coord._sections.get('C', '')


### PR DESCRIPTION
## Summary
- implement `_scan_paths` helper
- enable cross-album detection in `find_near_duplicates`
- remove unused placeholder HTML in `build_dry_run_html`
- document new cross-album scan feature
- test cross-album detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68819e4daf90832081ab7fd54e694a92