### PR TITLE
Simplify library duplicate scan

### DIFF
--- a/docs/project_documentation.html
+++ b/docs/project_documentation.html
@@ -578,9 +578,11 @@ if __name__ == "__main__":
 <h3>2.6 Tidal-dl Sync (<code>tidal_sync.py</code>)</h3>
 <p>Matches your library against tidal-dl downloads and replaces low-quality files
 with their FLAC counterparts. Debug logs can be written for troubleshooting.</p>
-<p>The module also provides <code>find_library_duplicates()</code> which runs the
-indexer's deduplication pass on your library. Place any new songs directly in
-the library and call this helper to list duplicate pairs chosen by quality.</p>
+<p>The module also provides <code>find_library_duplicates()</code> which performs
+a lightweight fingerprint scan to locate duplicate tracks in your library. Any
+new songs can simply be dropped into the library and this helper will compare
+fingerprints and return duplicate pairs with the preferred file chosen by
+format quality.</p>
 
 <hr>
 <h3>2.7 Normalize Genres (<code>normalize_controller.py</code>)</h3>

--- a/simple_duplicate_finder.py
+++ b/simple_duplicate_finder.py
@@ -1,0 +1,94 @@
+import os
+from typing import List, Tuple, Dict, Optional
+
+from fingerprint_cache import get_fingerprint
+from near_duplicate_detector import fingerprint_distance
+
+SUPPORTED_EXTS = {".flac", ".m4a", ".aac", ".mp3", ".wav", ".ogg"}
+EXT_PRIORITY = {".flac": 0, ".m4a": 1, ".aac": 1, ".mp3": 2, ".wav": 3, ".ogg": 4}
+FP_PREFIX_LEN = 16
+
+
+def _compute_fp(path: str) -> Tuple[Optional[int], Optional[str]]:
+    try:
+        import acoustid
+        return acoustid.fingerprint_file(path)
+    except Exception:
+        return None, None
+
+
+def _keep_score(path: str, ext_priority: Dict[str, int]) -> float:
+    ext = os.path.splitext(path)[1].lower()
+    pri = ext_priority.get(ext, 99)
+    ext_score = 1000.0 / (pri + 1)
+    fname_score = len(os.path.splitext(os.path.basename(path))[0])
+    return ext_score + fname_score
+
+
+def _walk_audio_files(root: str) -> List[str]:
+    paths: List[str] = []
+    for dirpath, _dirs, files in os.walk(root):
+        rel = os.path.relpath(dirpath, root)
+        parts = {p.lower() for p in rel.split(os.sep)}
+        if {"not sorted", "playlists"} & parts:
+            continue
+        for fname in files:
+            ext = os.path.splitext(fname)[1].lower()
+            if ext in SUPPORTED_EXTS:
+                paths.append(os.path.join(dirpath, fname))
+    return paths
+
+
+def find_duplicates(
+    root: str,
+    threshold: float = 0.03,
+    db_path: Optional[str] = None,
+    log_callback: Optional[callable] = None,
+) -> List[Tuple[str, str]]:
+    """Return list of duplicate pairs detected in ``root``."""
+    if db_path is None:
+        db_path = os.path.join(root, "Docs", ".simple_fps.db")
+
+    if log_callback is None:
+        def log_callback(msg: str) -> None:
+            pass
+
+    audio_paths = _walk_audio_files(root)
+    file_data: List[Tuple[str, str]] = []
+    for p in audio_paths:
+        fp = get_fingerprint(p, db_path, _compute_fp)
+        if fp:
+            file_data.append((p, fp))
+        else:
+            log_callback(f"No fingerprint for {p}")
+
+    groups: List[Dict[str, object]] = []
+    prefix_map: Dict[str, List[Dict[str, object]]] = {}
+    for path, fp in file_data:
+        prefix = fp[:FP_PREFIX_LEN]
+        cand_groups = prefix_map.get(prefix, [])
+        placed = False
+        for g in cand_groups:
+            dist = fingerprint_distance(fp, g["fp"])
+            if dist <= threshold:
+                g["paths"].append(path)
+                placed = True
+                break
+        if not placed:
+            g = {"fp": fp, "paths": [path]}
+            cand_groups.append(g)
+            prefix_map[prefix] = cand_groups
+            groups.append(g)
+
+    duplicates: List[Tuple[str, str]] = []
+    for g in groups:
+        paths = g["paths"]
+        if len(paths) <= 1:
+            continue
+        scored = sorted(paths, key=lambda p: _keep_score(p, EXT_PRIORITY), reverse=True)
+        keep = scored[0]
+        for dup in scored[1:]:
+            log_callback(f"Duplicate: keep {keep} -> drop {dup}")
+            duplicates.append((keep, dup))
+    return duplicates
+

--- a/tests/test_simple_duplicate_finder.py
+++ b/tests/test_simple_duplicate_finder.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import types
+import importlib
+
+import simple_duplicate_finder as sdf
+from fingerprint_cache import flush_cache
+
+
+def load_module(monkeypatch):
+    acoustid_stub = types.ModuleType('acoustid')
+    fp_map = {
+        'a.mp3': '1 2',
+        'b.flac': '1 2',
+        'c.mp3': '9 9',
+    }
+    acoustid_stub.fingerprint_file = lambda p: (0, fp_map[os.path.basename(p)])
+    monkeypatch.setitem(sys.modules, 'acoustid', acoustid_stub)
+    importlib.reload(sdf)
+    return sdf
+
+
+def test_duplicate_detection(tmp_path, monkeypatch):
+    sdf_mod = load_module(monkeypatch)
+    (tmp_path / 'a.mp3').write_text('x')
+    (tmp_path / 'b.flac').write_text('x')
+    (tmp_path / 'c.mp3').write_text('x')
+    db = tmp_path / 'fp.db'
+    dups = sdf_mod.find_duplicates(str(tmp_path), db_path=str(db))
+    pair = (str(tmp_path / 'b.flac'), str(tmp_path / 'a.mp3'))
+    assert pair in dups or (pair[1], pair[0]) in dups
+    flush_cache(str(db))
+

--- a/tidal_sync.py
+++ b/tidal_sync.py
@@ -460,15 +460,15 @@ def find_library_duplicates(
 ) -> List[Tuple[str, str]]:
     """Return duplicate track pairs detected within ``library_root``.
 
-    New songs should be placed directly inside the library before running so
-    the indexer's dedupe logic can compare everything at once. The returned
-    list contains ``(original_path, duplicate_path)`` pairs as determined by
-    :func:`music_indexer_api.find_duplicates` which prefers higher quality
-    formats when choosing the file to keep.
+    This version uses a lightweight fingerprint scan rather than invoking the
+    full indexer. Each audio file is fingerprinted or loaded from the cache and
+    compared against others to locate duplicates. The file with the best format
+    score is chosen to keep for each group.
     """
-    from music_indexer_api import find_duplicates as _find
 
-    return _find(library_root, log_callback)
+    from simple_duplicate_finder import find_duplicates as _find
+
+    return _find(library_root, log_callback=log_callback)
 
 
 def match_downloads(


### PR DESCRIPTION
## Summary
- introduce `simple_duplicate_finder` with standalone fingerprint based scanner
- use the new finder in `tidal_sync.find_library_duplicates`
- document the lighter workflow
- add regression test for duplicate finder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881a03944348320ae5d3cb2a0ea91ac