### PR TITLE
Restore verbose debug logging in Library Quality

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -2110,9 +2110,12 @@ class SoundVaultImporterApp(tk.Tk):
         self.match_queue = q
         self.matches = []
 
+        def log_line(msg: str) -> None:
+            self.after(0, lambda m=msg: self._log(m))
+
         def task() -> None:
             try:
-                dups = tidal_sync.find_library_duplicates(path, log_callback=self._log)
+                dups = tidal_sync.find_library_duplicates(path, log_callback=log_line)
                 q.put(dups)
             except Exception as e:
                 q.put(("error", str(e)))


### PR DESCRIPTION
## Summary
- ensure verbose debug output works for Library Quality duplicate scan

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881a50245d88320ab793399d59f9c38