### PR TITLE
Fix duplicate finder logging and fp

### DIFF
--- a/fingerprint_generator.py
+++ b/fingerprint_generator.py
@@ -73,8 +73,7 @@ def compute_fingerprints_parallel(
 ) -> None:
     """Walk ``root_path`` and compute fingerprints using multiple processes."""
     if log_callback is None:
-        def log_callback(msg: str) -> None:
-            pass
+        log_callback = print
 
     if progress_callback is None:
         def progress_callback(current: int, total: int, msg: str, _phase: str) -> None:

--- a/library_sync.py
+++ b/library_sync.py
@@ -49,10 +49,13 @@ def _dlog(msg: str, log_callback: Callable[[str], None] | None = None) -> None:
     _logger.debug(msg)
 
 
+import chromaprint_utils
+
+
 def _compute_fp(path: str) -> tuple[int | None, str | None]:
     try:
-        import acoustid
-        return acoustid.fingerprint_file(path)
+        fp = chromaprint_utils.fingerprint_fpcalc(path)
+        return 0, fp
     except Exception:
         return None, None
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,9 +15,9 @@ id3_stub.ID3NoHeaderError = Exception
 mutagen_stub.id3 = id3_stub
 sys.modules['mutagen'] = mutagen_stub
 sys.modules['mutagen.id3'] = id3_stub
-acoustid_stub = types.ModuleType('acoustid')
-acoustid_stub.fingerprint_file = lambda p: (0, 'hash')
-sys.modules['acoustid'] = acoustid_stub
+chroma_stub = types.ModuleType('chromaprint_utils')
+chroma_stub.fingerprint_fpcalc = lambda p: 'hash'
+sys.modules['chromaprint_utils'] = chroma_stub
 
 from music_indexer_api import main
 

--- a/tests/test_fingerprint_error.py
+++ b/tests/test_fingerprint_error.py
@@ -25,8 +25,10 @@ def load_ts(monkeypatch):
     monkeypatch.setitem(sys.modules, 'mutagen.id3', id3_stub)
     monkeypatch.setitem(sys.modules, 'mutagen.mp3', mp3_stub)
 
-    acoustid_stub = types.ModuleType('acoustid')
-    monkeypatch.setitem(sys.modules, 'acoustid', acoustid_stub)
+    chroma_stub = types.ModuleType('chromaprint_utils')
+    chroma_stub.FingerprintError = RuntimeError
+    chroma_stub.fingerprint_fpcalc = lambda *_a, **_k: ''
+    monkeypatch.setitem(sys.modules, 'chromaprint_utils', chroma_stub)
 
     import tidal_sync
     importlib.reload(tidal_sync)
@@ -46,7 +48,7 @@ def test_fingerprint_logs_exception(tmp_path, monkeypatch):
 
     def bad_fp(*a, **k):
         raise RuntimeError('boom')
-    monkeypatch.setattr(sys.modules['acoustid'], 'fingerprint_file', bad_fp, raising=False)
+    monkeypatch.setattr(sys.modules['chromaprint_utils'], 'fingerprint_fpcalc', bad_fp, raising=False)
 
     p = tmp_path / 'a.mp3'
     p.write_text('x')

--- a/tests/test_html_phases.py
+++ b/tests/test_html_phases.py
@@ -16,9 +16,9 @@ id3_stub.ID3NoHeaderError = Exception
 mutagen_stub.id3 = id3_stub
 sys.modules['mutagen'] = mutagen_stub
 sys.modules['mutagen.id3'] = id3_stub
-acoustid_stub = types.ModuleType('acoustid')
-acoustid_stub.fingerprint_file = lambda p: (0, 'hash')
-sys.modules['acoustid'] = acoustid_stub
+chroma_stub = types.ModuleType('chromaprint_utils')
+chroma_stub.fingerprint_fpcalc = lambda p: 'hash'
+sys.modules['chromaprint_utils'] = chroma_stub
 
 from music_indexer_api import build_dry_run_html
 

--- a/tests/test_library_sync.py
+++ b/tests/test_library_sync.py
@@ -2,7 +2,7 @@ import types
 import sys
 import os
 
-# Stub mutagen and acoustid
+# Stub mutagen and chromaprint_utils
 mutagen_stub = types.ModuleType('mutagen')
 class DummyAudio:
     def __init__(self, bitrate=128000):
@@ -18,15 +18,15 @@ mutagen_stub.id3 = id3_stub
 sys.modules['mutagen'] = mutagen_stub
 sys.modules['mutagen.id3'] = id3_stub
 
-acoustid_stub = types.ModuleType('acoustid')
+chroma_stub = types.ModuleType('chromaprint_utils')
 fp_map = {
     'a.flac': '1 2',
     'b.mp3': '2 3',
     'b.flac': '2 3',
     'new.mp3': '9 9',
 }
-acoustid_stub.fingerprint_file = lambda p: (0, fp_map.get(os.path.basename(p), 'x'))
-sys.modules['acoustid'] = acoustid_stub
+chroma_stub.fingerprint_fpcalc = lambda p: fp_map.get(os.path.basename(p), 'x')
+sys.modules['chromaprint_utils'] = chroma_stub
 
 import importlib
 import music_indexer_api
@@ -133,10 +133,10 @@ def test_format_threshold_match(tmp_path, monkeypatch):
 
     def fake_fp(path):
         if path.endswith(".wav"):
-            return 0, "1 2 3 4"
-        return 0, "1 2 3 5"
+            return "1 2 3 4"
+        return "1 2 3 5"
 
-    monkeypatch.setattr(sys.modules["acoustid"], "fingerprint_file", fake_fp)
+    monkeypatch.setattr(sys.modules["chromaprint_utils"], "fingerprint_fpcalc", fake_fp)
 
     db = tmp_path / "fp.db"
     res = compare_libraries(
@@ -172,10 +172,10 @@ def test_compare_libraries_relaxed_threshold(tmp_path, monkeypatch):
 
     def fake_fp(path):
         if path.endswith(".wav"):
-            return 0, "10 20 30 40 50"
-        return 0, "10 20 30 40 51"
+            return "10 20 30 40 50"
+        return "10 20 30 40 51"
 
-    monkeypatch.setattr(sys.modules["acoustid"], "fingerprint_file", fake_fp)
+    monkeypatch.setattr(sys.modules["chromaprint_utils"], "fingerprint_fpcalc", fake_fp)
 
     db = tmp_path / "fp.db"
     res = compare_libraries(

--- a/tests/test_simple_duplicate_finder.py
+++ b/tests/test_simple_duplicate_finder.py
@@ -8,14 +8,14 @@ from fingerprint_cache import flush_cache
 
 
 def load_module(monkeypatch):
-    acoustid_stub = types.ModuleType('acoustid')
+    chroma_stub = types.ModuleType('chromaprint_utils')
     fp_map = {
         'a.mp3': '1 2',
         'b.flac': '1 2',
         'c.mp3': '9 9',
     }
-    acoustid_stub.fingerprint_file = lambda p: (0, fp_map[os.path.basename(p)])
-    monkeypatch.setitem(sys.modules, 'acoustid', acoustid_stub)
+    chroma_stub.fingerprint_fpcalc = lambda p: fp_map[os.path.basename(p)]
+    monkeypatch.setitem(sys.modules, 'chromaprint_utils', chroma_stub)
     importlib.reload(sdf)
     return sdf
 

--- a/tests/test_tidal_sync.py
+++ b/tests/test_tidal_sync.py
@@ -25,9 +25,9 @@ def load_module(monkeypatch):
     monkeypatch.setitem(sys.modules, 'mutagen.id3', id3_stub)
     monkeypatch.setitem(sys.modules, 'mutagen.mp3', mp3_stub)
 
-    acoustid_stub = types.ModuleType('acoustid')
-    acoustid_stub.fingerprint_file = lambda p: (0, '')
-    monkeypatch.setitem(sys.modules, 'acoustid', acoustid_stub)
+    chroma_stub = types.ModuleType('chromaprint_utils')
+    chroma_stub.fingerprint_fpcalc = lambda p: ''
+    monkeypatch.setitem(sys.modules, 'chromaprint_utils', chroma_stub)
 
     import tidal_sync
     importlib.reload(tidal_sync)


### PR DESCRIPTION
## Summary
- use Chromaprint backend and show log output
- ensure cache dir exists and log stat errors
- default log callbacks to print
- update library and finder fingerprint helpers
- adjust tests for Chromaprint stubs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f3060b988320a6cf087ba14ea3a8