### PR TITLE
Fix fpcalc command and strip Windows long path prefix

### DIFF
--- a/chromaprint_utils.py
+++ b/chromaprint_utils.py
@@ -4,6 +4,8 @@ import os
 import json
 import shutil
 
+from utils.path_helpers import strip_long_path_prefix
+
 class FingerprintError(Exception):
     """Raised when fingerprint computation fails."""
 
@@ -73,7 +75,8 @@ def fingerprint_fpcalc(
                 min_silence_duration=min_silence_duration,
             )
             to_process = tmp
-        cmd = ["fpcalc", "-json", to_process]
+        safe_path = strip_long_path_prefix(to_process)
+        cmd = ["fpcalc", "-json", safe_path]
         proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
         if proc.returncode != 0:
             raise FingerprintError(proc.stderr.strip())

--- a/tests/test_fpcalc_invocation.py
+++ b/tests/test_fpcalc_invocation.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+
+# reload real module in case previous tests replaced it with a stub
+sys.modules.pop('chromaprint_utils', None)
+cu = importlib.import_module('chromaprint_utils')
+
+
+def test_fpcalc_invocation_and_prefix(monkeypatch):
+    monkeypatch.setattr(cu, "ensure_tool", lambda name: None)
+    monkeypatch.setattr(cu, "strip_long_path_prefix", lambda p: p[4:] if p.startswith("\\\\?\\") else p)
+
+    captured = {}
+
+    def fake_run(cmd, stdout=None, stderr=None, text=None):
+        captured['cmd'] = cmd
+        class P:
+            returncode = 0
+            stdout = '{"fingerprint": "1,2,3"}'
+            stderr = ''
+        return P()
+
+    monkeypatch.setattr(cu.subprocess, 'run', fake_run)
+
+    path = "\\\\?\\C:\\music\\song.flac"
+    fp = cu.fingerprint_fpcalc(path, trim=False)
+
+    assert fp == '1 2 3'
+    assert captured['cmd'][1] == '-json'
+    assert captured['cmd'][2] == r"C:\music\song.flac"

--- a/utils/path_helpers.py
+++ b/utils/path_helpers.py
@@ -7,3 +7,10 @@ def ensure_long_path(path: str) -> str:
         if not path.startswith("\\\\?\\"):
             path = "\\\\?\\" + os.path.normpath(path)
     return path
+
+
+def strip_long_path_prefix(path: str) -> str:
+    """Return path without a Windows extended-length prefix."""
+    if os.name == "nt" and path.startswith(r"\\?\\"):
+        return path[4:]
+    return path


### PR DESCRIPTION
## Summary
- add `strip_long_path_prefix` helper in `utils.path_helpers`
- use the helper when running `fpcalc`
- test fpcalc invocation without Windows long path prefix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688301767e68832099330c3b0b5044eb