### PR TITLE
Fix fpcalc path handling

### DIFF
--- a/chromaprint_utils.py
+++ b/chromaprint_utils.py
@@ -4,7 +4,10 @@ import os
 import json
 import shutil
 
-from utils.path_helpers import strip_long_path_prefix
+from utils.path_helpers import strip_ext_prefix
+
+# Backwards compatibility -------------------------------------------------
+strip_long_path_prefix = strip_ext_prefix
 
 class FingerprintError(Exception):
     """Raised when fingerprint computation fails."""
@@ -75,7 +78,7 @@ def fingerprint_fpcalc(
                 min_silence_duration=min_silence_duration,
             )
             to_process = tmp
-        safe_path = strip_long_path_prefix(to_process)
+        safe_path = strip_ext_prefix(to_process)
         cmd = ["fpcalc", "-json", safe_path]
         proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
         if proc.returncode != 0:

--- a/fingerprint_examples.py
+++ b/fingerprint_examples.py
@@ -10,10 +10,7 @@ import subprocess
 from pathlib import Path
 from typing import Iterable
 
-
-def strip_ext_prefix(p: str) -> str:
-    """Remove Windows extended-length path prefix."""
-    return p[4:] if p.startswith(r"\\?\\") else p
+from utils.path_helpers import strip_ext_prefix
 
 
 def expand_files(inputs: Iterable[str]) -> list[str]:

--- a/tests/test_fpcalc_invocation.py
+++ b/tests/test_fpcalc_invocation.py
@@ -8,7 +8,7 @@ cu = importlib.import_module('chromaprint_utils')
 
 def test_fpcalc_invocation_and_prefix(monkeypatch):
     monkeypatch.setattr(cu, "ensure_tool", lambda name: None)
-    monkeypatch.setattr(cu, "strip_long_path_prefix", lambda p: p[4:] if p.startswith("\\\\?\\") else p)
+    monkeypatch.setattr(cu, "strip_ext_prefix", lambda p: p[4:] if p.startswith("\\\\?\\") else p)
 
     captured = {}
 

--- a/utils/path_helpers.py
+++ b/utils/path_helpers.py
@@ -9,8 +9,12 @@ def ensure_long_path(path: str) -> str:
     return path
 
 
-def strip_long_path_prefix(path: str) -> str:
-    """Return path without a Windows extended-length prefix."""
+def strip_ext_prefix(path: str) -> str:
+    """Return ``path`` without a Windows extended-length prefix."""
     if os.name == "nt" and path.startswith(r"\\?\\"):
         return path[4:]
     return path
+
+
+# Backwards compatibility -------------------------------------------------
+strip_long_path_prefix = strip_ext_prefix


### PR DESCRIPTION
## Summary
- add reusable `strip_ext_prefix` helper
- use `strip_ext_prefix` when running `fpcalc`
- reference the helper in the fpcalc example script
- update fpcalc invocation test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68840cd13ebc8320a2a501c2afbd9ebe