### PR TITLE
Fix missing get_tags import

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -32,7 +32,11 @@ import textwrap
 import time
 
 from validator import validate_soundvault_structure
-from music_indexer_api import run_full_indexer, find_duplicates as api_find_duplicates
+from music_indexer_api import (
+    run_full_indexer,
+    find_duplicates as api_find_duplicates,
+    get_tags,
+)
 import simple_duplicate_finder as sdf_mod
 import fingerprint_cache
 import chromaprint_utils


### PR DESCRIPTION
## Summary
- import `get_tags` in `main_gui.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688611317dd08320a01d0f0bded3664e