### PR TITLE
Track missing fingerprints during duplicate scan

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -1072,9 +1072,14 @@ class SoundVaultImporterApp(tk.Tk):
                 self.after(0, lambda m=msg: self._log(m))
 
             try:
-                dups = sdf_mod.find_duplicates(folder, threshold=thr, log_callback=cb)
+                dups, missing = sdf_mod.find_duplicates(
+                    folder, threshold=thr, log_callback=cb
+                )
                 self.after(0, lambda: self._log(f"Found {len(dups)} duplicate pairs"))
                 self.after(0, lambda: self.populate_quality_table(dups))
+                if missing:
+                    msg = f"{missing} files could not be fingerprinted."
+                    self.after(0, lambda m=msg: self._log(m))
             finally:
                 self._dup_logging = False
                 self.after(0, lambda: self.scan_btn.config(state="normal"))

--- a/tests/test_simple_duplicate_finder.py
+++ b/tests/test_simple_duplicate_finder.py
@@ -26,8 +26,9 @@ def test_duplicate_detection(tmp_path, monkeypatch):
     (tmp_path / 'b.flac').write_text('x')
     (tmp_path / 'c.mp3').write_text('x')
     db = tmp_path / 'fp.db'
-    dups = sdf_mod.find_duplicates(str(tmp_path), db_path=str(db))
+    dups, missing = sdf_mod.find_duplicates(str(tmp_path), db_path=str(db))
     pair = (str(tmp_path / 'b.flac'), str(tmp_path / 'a.mp3'))
     assert pair in dups or (pair[1], pair[0]) in dups
+    assert missing == 0
     flush_cache(str(db))
 


### PR DESCRIPTION
## Summary
- catch `FingerprintError` separately in `_compute_fp`
- count missing fingerprints in `find_duplicates`
- return `(duplicates, missing_count)` and display the count in the GUI
- update test for new return type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68882b70089483209beee82d36bcd826