### PR TITLE
Add distance range reporting to duplicate finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ threshold used during deduplication, add a value like:
 
 Lower values require more similar fingerprints.
 
+Typical duplicate distances fall between **0.02** and **0.15** when using
+Chromaprint fingerprints. After a scan the GUI will report the smallest and
+largest distances seen so you can fine‑tune your threshold.
+
 Per-format fingerprint thresholds used by the sync matcher can also be
 configured. Add a `format_fp_thresholds` section with extension keys:
 

--- a/main_gui.py
+++ b/main_gui.py
@@ -1072,10 +1072,16 @@ class SoundVaultImporterApp(tk.Tk):
                 self.after(0, lambda m=msg: self._log(m))
 
             try:
-                dups, missing = sdf_mod.find_duplicates(
+                dups, missing, min_d, max_d = sdf_mod.find_duplicates(
                     folder, threshold=thr, log_callback=cb
                 )
                 self.after(0, lambda: self._log(f"Found {len(dups)} duplicate pairs"))
+                self.after(
+                    0,
+                    lambda: self._log(
+                        f"Distances ranged from {min_d:.2f} to {max_d:.2f}"
+                    ),
+                )
                 self.after(0, lambda: self.populate_quality_table(dups))
                 if missing:
                     msg = f"{missing} files could not be fingerprinted."

--- a/tests/test_simple_duplicate_finder.py
+++ b/tests/test_simple_duplicate_finder.py
@@ -26,9 +26,11 @@ def test_duplicate_detection(tmp_path, monkeypatch):
     (tmp_path / 'b.flac').write_text('x')
     (tmp_path / 'c.mp3').write_text('x')
     db = tmp_path / 'fp.db'
-    dups, missing = sdf_mod.find_duplicates(str(tmp_path), db_path=str(db))
+    dups, missing, min_d, max_d = sdf_mod.find_duplicates(str(tmp_path), db_path=str(db))
     pair = (str(tmp_path / 'b.flac'), str(tmp_path / 'a.mp3'))
     assert pair in dups or (pair[1], pair[0]) in dups
     assert missing == 0
+    assert min_d == 0.0
+    assert max_d == 0.0
     flush_cache(str(db))
 


### PR DESCRIPTION
## Summary
- record min/max fingerprint distances during duplicate grouping
- show distance range in Quality Checker output
- document typical duplicate distance range
- update simple duplicate finder test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68882df6d7988320870f8c82688e9f5e