### PR TITLE
Stop overlapping audio in duplicate finder

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -44,6 +44,7 @@ from controllers.library_index_controller import generate_index
 from controllers.import_controller import import_new_files
 from controllers.genre_list_controller import list_unique_genres
 from controllers.highlight_controller import play_snippet, PYDUB_AVAILABLE
+from gui.audio_preview import play_preview as _play_clip
 from io import BytesIO
 from PIL import Image, ImageTk
 from mutagen import File as MutagenFile
@@ -2281,7 +2282,7 @@ class SoundVaultImporterApp(tk.Tk):
 
         def task() -> None:
             try:
-                play_snippet(path)
+                _play_clip(path)
             except Exception as e:
                 self.after(0, lambda: messagebox.showerror("Playback failed", str(e)))
 


### PR DESCRIPTION
## Summary
- use shared audio preview helper when playing duplicate previews

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68884548ac088320b72d8426bed0bda6