### PR TITLE
Improve playlist updating

### DIFF
--- a/controllers/library_controller.py
+++ b/controllers/library_controller.py
@@ -1,6 +1,7 @@
 import os
 import json
-from typing import Tuple, Dict, Callable
+from typing import Tuple, Dict, Callable, Iterable
+from controllers.playlist_controller import save_playlist as _save
 from validator import validate_soundvault_structure
 
 CONFIG_FILE = os.path.join(os.path.dirname(__file__), "..", "last_path.txt")
@@ -57,7 +58,10 @@ def open_library(folder_path: str, progress_callback: Callable[[int], None] | No
     return info
 
 
-def save_playlist():
-    """Trigger playlist engine export (stub)."""
-    # TODO: implement real playlist export
-    pass
+def save_playlist(library_path: str, name: str, tracks: Iterable[str]) -> str:
+    """Save a playlist inside ``library_path`` and update auto playlists."""
+
+    playlists_dir = os.path.join(library_path, "Playlists")
+    os.makedirs(playlists_dir, exist_ok=True)
+    out_path = os.path.join(playlists_dir, f"{name}.m3u")
+    return _save(tracks, out_path)

--- a/controllers/playlist_controller.py
+++ b/controllers/playlist_controller.py
@@ -1,7 +1,18 @@
 """Playlist export helpers."""
 
+from __future__ import annotations
 
-def save_playlist():
-    """Stub for playlist export."""
-    # TODO: move playlist export logic here
-    pass
+import os
+from typing import Iterable
+
+from playlist_generator import write_playlist, update_playlists
+
+
+def save_playlist(tracks: Iterable[str], outfile: str) -> str:
+    """Write ``tracks`` to ``outfile`` and refresh library playlists."""
+
+    write_playlist(list(tracks), outfile)
+
+    abs_tracks = [os.path.abspath(p) for p in tracks]
+    update_playlists(abs_tracks)
+    return outfile


### PR DESCRIPTION
## Summary
- expand `playlist_generator.update_playlists` to rewrite playlists when tracks move or are removed
- implement `save_playlist` in `playlist_controller` to write playlists and refresh auto-playlists
- implement `save_playlist` in `library_controller` to save playlists for a library

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a84b7b22c83208abcc6b1d322d234