### PR TITLE
Ensure only one preview plays in Quality Checker

### DIFF
--- a/gui/audio_preview.py
+++ b/gui/audio_preview.py
@@ -1,7 +1,11 @@
 from pydub import AudioSegment
 import simpleaudio as sa
-from tkinter import messagebox
 import threading
+
+
+class PlaybackError(Exception):
+    """Raised when preview playback fails."""
+
 
 _play_obj = None
 _play_lock = threading.Lock()
@@ -32,4 +36,14 @@ def play_preview(path: str, start_ms: int = 30000, duration_ms: int = 15000) -> 
                 sample_rate=clip.frame_rate,
             )
     except Exception as exc:
-        messagebox.showerror("Playback Error", str(exc))
+        raise PlaybackError(str(exc)) from exc
+
+
+def stop_preview() -> None:
+    """Stop any currently playing preview."""
+    global _play_obj
+    with _play_lock:
+        if _play_obj and _play_obj.is_playing():
+            _play_obj.stop()
+        _play_obj = None
+

--- a/main_gui.py
+++ b/main_gui.py
@@ -44,7 +44,7 @@ from controllers.library_index_controller import generate_index
 from controllers.import_controller import import_new_files
 from controllers.genre_list_controller import list_unique_genres
 from controllers.highlight_controller import play_snippet, PYDUB_AVAILABLE
-from gui.audio_preview import play_preview as _play_clip
+from gui.audio_preview import play_preview as _play_clip, stop_preview
 from io import BytesIO
 from PIL import Image, ImageTk
 from mutagen import File as MutagenFile
@@ -2347,6 +2347,8 @@ class SoundVaultImporterApp(tk.Tk):
                 "pydub/ffmpeg not available. Install requirements to enable preview.",
             )
             return
+
+        stop_preview()
 
         def task() -> None:
             try:


### PR DESCRIPTION
## Summary
- introduce `PlaybackError` and `stop_preview` to manage preview playback
- handle preview errors in the main UI thread and stop any existing preview before starting a new one

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ab4b4eef48320b3a1872bcbc23004