### PR TITLE
Add crash log handler

### DIFF
--- a/crash_logger.py
+++ b/crash_logger.py
@@ -1,0 +1,27 @@
+import logging
+import sys
+import traceback
+
+
+def install(log_path: str = "crash.log") -> None:
+    """Log unhandled exceptions to ``log_path``.
+
+    The log file is overwritten on each run.
+    """
+    logger = logging.getLogger("crash")
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+    handler = logging.FileHandler(log_path, mode="w", encoding="utf-8")
+    handler.setFormatter(logging.Formatter("%(asctime)s %(message)s"))
+    logger.handlers.clear()
+    logger.addHandler(handler)
+
+    def _handle(exc_type, exc_value, exc_tb):
+        if issubclass(exc_type, KeyboardInterrupt):
+            sys.__excepthook__(exc_type, exc_value, exc_tb)
+            return
+        msg = "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
+        logger.critical("Unhandled exception:\n%s", msg)
+        sys.__excepthook__(exc_type, exc_value, exc_tb)
+
+    sys.excepthook = _handle

--- a/main_gui.py
+++ b/main_gui.py
@@ -2523,5 +2523,8 @@ class SoundVaultImporterApp(tk.Tk):
 
 
 if __name__ == "__main__":
+    from crash_logger import install as install_crash_logger
+
+    install_crash_logger()
     app = SoundVaultImporterApp()
     app.mainloop()

--- a/music_indexer_api.py
+++ b/music_indexer_api.py
@@ -1157,4 +1157,7 @@ def main(argv: List[str] | None = None) -> None:
 
 
 if __name__ == "__main__":
+    from crash_logger import install as install_crash_logger
+
+    install_crash_logger()
     main()


### PR DESCRIPTION
## Summary
- create a crash_logger module for writing unhandled exceptions to a file
- initialize crash logging when running the CLI or GUI directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ac0e87e9483209542cd3e73408e98