### PR TITLE
Refactor audio preview handling

### DIFF
--- a/gui/audio_preview.py
+++ b/gui/audio_preview.py
@@ -9,71 +9,73 @@ class PlaybackError(Exception):
     """Raised when preview playback fails."""
 
 
-_play_obj = None
-_play_lock = threading.Lock()
-_ffplay_proc = None
+class PreviewPlayer:
+    """Play short audio previews with thread-safe state."""
 
-def play_preview(path: str, start_ms: int = 30000, duration_ms: int = 15000) -> None:
-    """Play a short preview of the audio file at ``path``.
+    def __init__(self) -> None:
+        self._play_obj = None
+        self._ffplay_proc = None
+        self._play_lock = threading.Lock()
 
-    Parameters
-    ----------
-    path : str
-        File path of the audio clip.
-    start_ms : int, optional
-        Starting point in milliseconds, by default 30000.
-    duration_ms : int, optional
-        Duration of the preview in milliseconds, by default 15000.
-    """
-    global _play_obj, _ffplay_proc
-    stop_preview()
-    try:
-        audio = AudioSegment.from_file(path)
-        clip = audio[start_ms : start_ms + duration_ms]
-        with _play_lock:
-            _play_obj = sa.play_buffer(
-                clip.raw_data,
-                num_channels=clip.channels,
-                bytes_per_sample=clip.sample_width,
-                sample_rate=clip.frame_rate,
-            )
-        return
-    except Exception as exc:
-        sa_error = exc
+    def play_preview(
+        self, path: str, start_ms: int = 30000, duration_ms: int = 15000
+    ) -> None:
+        """Play a short preview of the audio file at ``path``.
 
-    ffplay = shutil.which("ffplay")
-    if not ffplay:
-        raise PlaybackError(str(sa_error)) from sa_error
-    try:
-        cmd = [
-            ffplay,
-            "-nodisp",
-            "-autoexit",
-            "-loglevel",
-            "quiet",
-            "-ss",
-            str(start_ms / 1000),
-            "-t",
-            str(duration_ms / 1000),
-            path,
-        ]
-        _ffplay_proc = subprocess.Popen(cmd)
-    except Exception as exc:
-        raise PlaybackError(str(exc)) from exc
-
-
-def stop_preview() -> None:
-    """Stop any currently playing preview."""
-    global _play_obj, _ffplay_proc
-    with _play_lock:
-        if _play_obj and _play_obj.is_playing():
-            _play_obj.stop()
-        _play_obj = None
-    if _ffplay_proc and _ffplay_proc.poll() is None:
-        _ffplay_proc.terminate()
+        Parameters
+        ----------
+        path : str
+            File path of the audio clip.
+        start_ms : int, optional
+            Starting point in milliseconds, by default 30000.
+        duration_ms : int, optional
+            Duration of the preview in milliseconds, by default 15000.
+        """
+        self.stop_preview()
         try:
-            _ffplay_proc.wait(timeout=1)
-        except Exception:
-            _ffplay_proc.kill()
-    _ffplay_proc = None
+            audio = AudioSegment.from_file(path)
+            clip = audio[start_ms : start_ms + duration_ms]
+            with self._play_lock:
+                self._play_obj = sa.play_buffer(
+                    clip.raw_data,
+                    num_channels=clip.channels,
+                    bytes_per_sample=clip.sample_width,
+                    sample_rate=clip.frame_rate,
+                )
+            return
+        except Exception as exc:
+            sa_error = exc
 
+        ffplay = shutil.which("ffplay")
+        if not ffplay:
+            raise PlaybackError(str(sa_error)) from sa_error
+        try:
+            cmd = [
+                ffplay,
+                "-nodisp",
+                "-autoexit",
+                "-loglevel",
+                "quiet",
+                "-ss",
+                str(start_ms / 1000),
+                "-t",
+                str(duration_ms / 1000),
+                path,
+            ]
+            self._ffplay_proc = subprocess.Popen(cmd)
+        except Exception as exc:
+            raise PlaybackError(str(exc)) from exc
+
+    def stop_preview(self) -> None:
+        """Stop any currently playing preview."""
+        with self._play_lock:
+            if self._play_obj and self._play_obj.is_playing():
+                self._play_obj.stop()
+            self._play_obj = None
+        if self._ffplay_proc and self._ffplay_proc.poll() is None:
+            self._ffplay_proc.terminate()
+            try:
+                self._ffplay_proc.wait(timeout=1)
+            except Exception:
+                self._ffplay_proc.kill()
+        self._ffplay_proc = None

--- a/main_gui.py
+++ b/main_gui.py
@@ -45,7 +45,7 @@ from controllers.library_index_controller import generate_index
 from controllers.import_controller import import_new_files
 from controllers.genre_list_controller import list_unique_genres
 from controllers.highlight_controller import play_snippet, PYDUB_AVAILABLE
-from gui.audio_preview import play_preview as _play_clip, stop_preview
+from gui.audio_preview import PreviewPlayer
 from io import BytesIO
 from PIL import Image, ImageTk
 from mutagen import File as MutagenFile
@@ -453,6 +453,7 @@ class SoundVaultImporterApp(tk.Tk):
         # Quality Checker state
         self._dup_logging = False
         self._preview_thread = None
+        self.preview_player = PreviewPlayer()
 
         # assume ffmpeg is available without performing checks
         self.ffmpeg_available = True
@@ -2364,14 +2365,14 @@ class SoundVaultImporterApp(tk.Tk):
             )
             return
 
-        stop_preview()
+        self.preview_player.stop_preview()
 
         if self._preview_thread and self._preview_thread.is_alive():
             self._preview_thread.join(timeout=0.1)
 
         def task() -> None:
             try:
-                _play_clip(path)
+                self.preview_player.play_preview(path)
             except Exception as e:
                 self.after(0, lambda: messagebox.showerror("Playback failed", str(e)))
 
@@ -2517,7 +2518,7 @@ class SoundVaultImporterApp(tk.Tk):
 
     def _on_close(self):
         """Handle application close event."""
-        stop_preview()
+        self.preview_player.stop_preview()
         if self._preview_thread and self._preview_thread.is_alive():
             self._preview_thread.join(timeout=0.1)
         self.destroy()


### PR DESCRIPTION
## Summary
- encapsulate playback state in `PreviewPlayer`
- use `PreviewPlayer` from GUI for thread‑safe previews

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b4ec0f0688320a2f8e51c9e32a304