### PR TITLE
Add scanning progress window to Quality Checker

### DIFF
--- a/controllers/scan_progress_controller.py
+++ b/controllers/scan_progress_controller.py
@@ -1,0 +1,19 @@
+import threading
+from typing import Callable, Any
+
+
+class ScanProgressController:
+    """Helper for coordinating scan progress updates and cancellation."""
+
+    def __init__(self) -> None:
+        self.cancel_event = threading.Event()
+        self._callback: Callable[..., Any] | None = None
+
+    def set_callback(self, cb: Callable[..., Any]) -> None:
+        """Register a callback for progress events."""
+        self._callback = cb
+
+    def update(self, *args, **kwargs) -> None:
+        """Forward a progress event to the registered callback."""
+        if self._callback:
+            self._callback(*args, **kwargs)


### PR DESCRIPTION
## Summary
- add ScanProgressWindow displaying logs and determinate/indeterminate progress bar
- wire Quality Checker scans through ScanProgressController with cancel support
- emit progress events from simple_duplicate_finder during walking and fingerprinting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e5806aacc8320a02c875f8443e408