### PR TITLE
Preserve artist case in folder names

### DIFF
--- a/music_indexer_api.py
+++ b/music_indexer_api.py
@@ -510,9 +510,8 @@ def compute_moves_and_tag_index(
         genre   = data["genre"]
         track   = data["track"]
 
-        # 1) Primary & collabs (normalize case)
+        # 1) Primary & collabs (preserve original case)
         primary, collabs = extract_primary_and_collabs(raw_artist)
-        primary = primary.upper()
         p_lower = primary.lower()
 
         # 2) album_counts for genuine (non-remix) tracks under each (artist, album)


### PR DESCRIPTION
## Summary
- Keep artist names in their original metadata case when indexing

## Testing
- `pytest`
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement mutagen)*

------
https://chatgpt.com/codex/tasks/task_e_68900be0719c8320ae0334cf99fb0017