### PR TITLE
Add import dry run preview

### DIFF
--- a/tests/test_import_preview_html.py
+++ b/tests/test_import_preview_html.py
@@ -1,0 +1,24 @@
+import os
+from controllers.import_controller import build_import_preview_html
+
+
+def test_import_preview_html_only_new(tmp_path):
+    root = tmp_path / "vault"
+    root.mkdir()
+
+    # existing library file that should not appear in preview
+    existing = root / "Music" / "Old" / "old.mp3"
+    existing.parent.mkdir(parents=True)
+    existing.write_text("dummy")
+
+    dest1 = root / "Music" / "Artist" / "song1.mp3"
+    dest2 = root / "Music" / "Artist" / "song2.mp3"
+    moves = {"a": str(dest1), "b": str(dest2)}
+    html = tmp_path / "preview.html"
+
+    build_import_preview_html(str(root), moves, str(html))
+    content = html.read_text()
+
+    assert "song1.mp3" in content
+    assert "song2.mp3" in content
+    assert "old.mp3" not in content


### PR DESCRIPTION
## Summary
- add HTML builder for import dry runs to show only newly added tracks
- integrate builder into import workflow
- test import preview generation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890fa72699c8320a732b16d83f4a50e