### PR TITLE
Batch fingerprinting in quality checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ pip install -r requirements.txt
 The indexer will exit with an error if the real `mutagen` package is missing,
 so ensure all dependencies are installed before running.
 
+The **Quality Checker** now imports the indexer's `fingerprint_generator`
+module. Make sure the Music Indexer package itself is installed (e.g.
+`pip install .`) so this dependency is available when running the Quality
+Checker.
+
 ## Quickstart
 
 ```bash


### PR DESCRIPTION
## Summary
- Batch audio paths and compute fingerprints in parallel for library sync
- Update tests for new fingerprinting strategy
- Document that Quality Checker relies on the indexer's fingerprint generator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897b248a6108320b41ec1bd9b5d8dc7