### PR TITLE
Add automatic cleanup for audio preview playback

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -2443,9 +2443,6 @@ class SoundVaultImporterApp(tk.Tk):
     def _play_preview(self, path: str) -> None:
         """Play an audio preview, ensuring previous playback is cleaned up."""
 
-        # Stop any existing playback first
-        self.preview_player.stop_preview()
-
         # Wait for previous thread to fully terminate
         if self._preview_thread and self._preview_thread.is_alive():
             self._preview_thread.join(timeout=1.0)


### PR DESCRIPTION
## Summary
- add monitor thread to auto-stop preview playback once audio or subprocess ends
- switch to re-entrant lock and spawn monitor from playback start
- remove redundant manual stop in GUI preview handler

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897d05a90d88320b9a444cba3b698e1