### PR TITLE
Add crash watcher instrumentation and crash summaries

### DIFF
--- a/controllers/tagfix_controller.py
+++ b/controllers/tagfix_controller.py
@@ -4,10 +4,14 @@ import sqlite3
 from typing import List, Callable
 
 from tag_fixer import build_file_records, init_db, find_files, apply_tag_proposals, FileRecord
+from crash_watcher import record_event
+from crash_logger import watcher
 
 
+@watcher.traced
 def prepare_library(folder: str) -> tuple[str, dict]:
     """Initialize DB and load saved genre mapping."""
+    record_event(f"tagfix_controller: preparing library {folder}")
     docs_dir = os.path.join(folder, "Docs")
     os.makedirs(docs_dir, exist_ok=True)
     db_path = os.path.join(docs_dir, ".soundvault.db")
@@ -21,14 +25,20 @@ def prepare_library(folder: str) -> tuple[str, dict]:
                 mapping = json.load(f)
         except Exception:
             mapping = {}
+    record_event("tagfix_controller: library prepared")
     return db_path, mapping
 
 
+@watcher.traced
 def discover_files(folder: str) -> List[str]:
     """Return supported audio files under ``folder``."""
-    return find_files(folder)
+    record_event(f"tagfix_controller: discovering files in {folder}")
+    files = find_files(folder)
+    record_event(f"tagfix_controller: found {len(files)} files")
+    return files
 
 
+@watcher.traced
 def gather_records(
     folder: str,
     db_path: str,
@@ -37,6 +47,7 @@ def gather_records(
     log_callback: Callable[[str], None] | None = None,
 ) -> List[FileRecord]:
     """Build FileRecord objects for ``folder``."""
+    record_event(f"tagfix_controller: gathering records for {folder}")
     db_folder = os.path.dirname(db_path)
     os.makedirs(db_folder, exist_ok=True)
     conn = sqlite3.connect(db_path)
@@ -49,11 +60,14 @@ def gather_records(
     )
     conn.commit()
     conn.close()
+    record_event(f"tagfix_controller: gathered {len(records)} records")
     return records
 
 
+@watcher.traced
 def apply_proposals(selected: List[FileRecord], all_records: List[FileRecord], db_path: str, fields: List[str], log_callback: Callable[[str], None]) -> int:
     """Apply tag proposals and update DB."""
+    record_event(f"tagfix_controller: applying {len(selected)} proposals")
     count = apply_tag_proposals(selected, fields=fields, log_callback=log_callback)
     selected_paths = {rec.path for rec in selected}
     db_folder = os.path.dirname(db_path)
@@ -73,4 +87,5 @@ def apply_proposals(selected: List[FileRecord], all_records: List[FileRecord], d
         )
     conn.commit()
     conn.close()
+    record_event(f"tagfix_controller: applied proposals to {count} files")
     return count

--- a/crash_watcher.py
+++ b/crash_watcher.py
@@ -26,8 +26,9 @@ class CrashWatcher(threading.Thread):
 
     def record_event(self, msg: str) -> None:
         ts = time.strftime("%Y-%m-%d %H:%M:%S")
+        thread = threading.current_thread().name
         with self._lock:
-            self._events.append(f"{ts} - {msg}")
+            self._events.append(f"{ts} [{thread}] {msg}")
 
     def dump_events(self) -> str:
         with self._lock:
@@ -55,6 +56,13 @@ def record_event(msg: str) -> None:
     """Record an event in the crash buffer."""
     if _watcher is not None:
         _watcher.record_event(msg)
+
+
+def dump_events() -> str:
+    """Return concatenated recent events."""
+    if _watcher is None:
+        return ""
+    return _watcher.dump_events()
 
 
 def mark_clean_shutdown() -> None:


### PR DESCRIPTION
## Summary
- Instrument long-running workflows with `record_event` via a new `watcher.traced` decorator
- Enhance crash logging to compile stack traces, thread names, timestamps, and recent events
- Surface crash summaries in a modal dialog and crash log

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898d9a1181c83208d56f8988c508a27