### PR TITLE
Defer heavy library scans and stats to keep startup animations smooth

### DIFF
--- a/alpha_dex_gui.py
+++ b/alpha_dex_gui.py
@@ -24,6 +24,14 @@ from __future__ import annotations
 import sys
 import os
 
+
+# Defer heavy workspace scans so landing/main cross-fade animations stay smooth.
+# Rule: initialize scans at whichever comes first:
+#   1) 30s after the landing first appears, or
+#   2) 3s after the user presses Initialize.
+_INIT_SCAN_MAX_DELAY_MS = 30_000
+_INIT_SCAN_AFTER_CLICK_MS = 3_000
+
 # Ensure the repo root is on sys.path so backend modules are importable
 _REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
 if _REPO_ROOT not in sys.path:
@@ -97,6 +105,8 @@ def main() -> int:
 
     # Show the landing immediately — it handles its own fade-in + logo pause
     # + tile fly-in sequence internally via show_animated().
+    startup_clock = QtCore.QElapsedTimer()
+    startup_clock.start()
     landing.show_animated()
 
     # ── Cross-fade: landing → main window ─────────────────────────────────────
@@ -116,7 +126,16 @@ def main() -> int:
             return
 
         if path:
-            window.set_library(path)
+            elapsed_ms = max(0, startup_clock.elapsed())
+            remaining_to_max = max(0, _INIT_SCAN_MAX_DELAY_MS - elapsed_ms)
+            init_delay_ms = min(remaining_to_max, _INIT_SCAN_AFTER_CLICK_MS)
+
+            # Keep the main-window transition responsive: defer expensive
+            # library initialization/scanning until shortly after Initialize.
+            QtCore.QTimer.singleShot(
+                init_delay_ms,
+                lambda p=path: window.set_library(p),
+            )
 
         # If the user clicked a tile, navigate to Player and start playing
         # before the window fades in so it's ready when it appears.

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -45,6 +45,8 @@ _WORKSPACE_MAP: dict[str, type[WorkspaceBase]] = {
     "help":         HelpWorkspace,
 }
 
+_LIBRARY_STATS_DELAY_MS = 3_000
+
 
 class AlphaDEXWindow(QtWidgets.QMainWindow):
     """Main application window."""
@@ -58,6 +60,10 @@ class AlphaDEXWindow(QtWidgets.QMainWindow):
         self._library_path: str = ""
         self._workspaces: dict[str, WorkspaceBase] = {}
         self._theme_picker = None   # keep reference so dialog stays open
+        self._pending_stats_path: str = ""
+        self._stats_timer = QtCore.QTimer(self)
+        self._stats_timer.setSingleShot(True)
+        self._stats_timer.timeout.connect(self._run_scheduled_stats)
 
         # Apply persisted theme before building UI
         get_manager().load_persisted()
@@ -204,7 +210,7 @@ class AlphaDEXWindow(QtWidgets.QMainWindow):
         self.statusBar().showMessage(f"Library: {path}")
 
         # Update stats in background
-        self._update_library_stats(path)
+        self._schedule_library_stats(path)
 
         # Persist
         try:
@@ -305,7 +311,17 @@ class AlphaDEXWindow(QtWidgets.QMainWindow):
         worker.setParent(self)
         # Keep reference so it doesn't get GC'd
         self._stats_worker = worker
-        worker.start()
+        worker.start(QtCore.QThread.Priority.LowPriority)
+
+    def _schedule_library_stats(self, path: str) -> None:
+        """Delay expensive full-library stat walk to keep startup animation smooth."""
+        self._pending_stats_path = path
+        self._stats_timer.start(_LIBRARY_STATS_DELAY_MS)
+
+    @Slot()
+    def _run_scheduled_stats(self) -> None:
+        if self._pending_stats_path:
+            self._update_library_stats(self._pending_stats_path)
 
     @Slot(int, float, int)
     def _on_stats_ready(self, tracks: int, size_gb: float, artists: int) -> None:

--- a/gui/widgets/landing.py
+++ b/gui/widgets/landing.py
@@ -60,6 +60,7 @@ _ART_SCAN_DEBUG: bool = True
 # During this window the CTA card ("AlphaDEX") is the only visible element —
 # this is the merged "logo moment" that replaces the old SplashScreen.
 _LOGO_PAUSE_MS: int = 600
+_ART_SCAN_START_DELAY_MS: int = 30_000
 
 # ── Colour pool — diagonal gradient pairs for placeholder tiles ───────────────
 _GRADS: list[tuple[str, str]] = [
@@ -810,6 +811,9 @@ class MosaicLanding(QtWidgets.QWidget):
         self._fade_in_anim:  object = None
         self._fade_out_anim: object = None
         self._scanner: object = None   # _ArtScanner | None
+        self._scan_start_timer = QtCore.QTimer(self)
+        self._scan_start_timer.setSingleShot(True)
+        self._scan_start_timer.timeout.connect(self._start_art_scanner)
         self._art_history: _ArtHistory | None = None  # Track for deferred save
 
         self._compute_grid()
@@ -892,9 +896,6 @@ class MosaicLanding(QtWidgets.QWidget):
         for tile in self._tiles:
             tile.clicked.connect(self._on_tile_clicked)
 
-        if self._saved:
-            self._start_art_scanner()
-
     def _build_cta(self) -> None:
         self._cta = _CTACard(self, self._saved)
         self._cta.setGeometry(self._center_rect)
@@ -919,6 +920,10 @@ class MosaicLanding(QtWidgets.QWidget):
         """
         self.setWindowOpacity(0.0)
         self.show()
+        if self._saved:
+            # Delay art scanning to keep startup I/O quieter while launch
+            # animations and main-window construction are in progress.
+            self._scan_start_timer.start(_ART_SCAN_START_DELAY_MS)
         anim = QtCore.QVariantAnimation(self)
         anim.setStartValue(0.0)
         anim.setEndValue(1.0)
@@ -988,6 +993,10 @@ class MosaicLanding(QtWidgets.QWidget):
         if not path:
             return
         self._pending = path
+        self._scan_start_timer.stop()
+        # Stop scanner immediately when the user commits to Initialize so
+        # disk-heavy directory work does not compete with transition animation.
+        self._stop_art_scanner()
 
         # Stop any running fly-in and snap all tiles to their resting positions
         if (
@@ -1043,15 +1052,7 @@ class MosaicLanding(QtWidgets.QWidget):
         anim.start()
 
     def _done(self) -> None:
-        if self._scanner is not None:
-            # Disconnect signals before cleanup to prevent race conditions
-            self._scanner.art_found.disconnect()
-            self._scanner.requestInterruption()
-            if not self._scanner.wait(2000):
-                # Thread did not exit cleanly; force termination
-                self._scanner.terminate()
-                self._scanner.wait()
-            self._scanner = None
+        self._stop_art_scanner()
         self.hide()
         self.finished.emit()
 
@@ -1071,10 +1072,24 @@ class MosaicLanding(QtWidgets.QWidget):
     # ── Art scanner ───────────────────────────────────────────────────────
 
     def _start_art_scanner(self) -> None:
+        if not self._saved or self._scanner is not None:
+            return
         scanner = _ArtScanner(self._saved, len(self._tiles))
         scanner.art_found.connect(self._on_art_found)
         self._scanner = scanner
         scanner.start()
+
+    def _stop_art_scanner(self) -> None:
+        if self._scanner is None:
+            return
+        # Disconnect signals before cleanup to prevent race conditions
+        self._scanner.art_found.disconnect()
+        self._scanner.requestInterruption()
+        if not self._scanner.wait(2000):
+            # Thread did not exit cleanly; force termination
+            self._scanner.terminate()
+            self._scanner.wait()
+        self._scanner = None
 
     def _on_art_found(self, tile_index: int, image: QtGui.QImage, dirpath: str) -> None:
         # We are back on the main thread here; QPixmap conversion is safe.


### PR DESCRIPTION
### Motivation

- Reduce startup jank by deferring disk-heavy work (art scanning and full-library stat walks) so landing/main cross-fade and tile animations remain responsive. 

### Description

- In `alpha_dex_gui.py` add timing rules and a startup clock and schedule `window.set_library()` to run after a short delay to ensure initialization/scanning is deferred until after the transition. 
- In `gui/main_window.py` introduce `_LIBRARY_STATS_DELAY_MS`, run the `_StatsWorker` with `LowPriority`, and replace immediate stat updates with `_schedule_library_stats()` backed by a single-shot `QTimer` that calls `_update_library_stats()` after a delay. 
- In `gui/widgets/landing.py` add `_ART_SCAN_START_DELAY_MS`, a `_scan_start_timer` to delay starting `_ArtScanner` until after the landing animation, and centralize scanner shutdown into `_stop_art_scanner()` that safely disconnects signals and waits/terminates the thread if needed. 

### Testing

- Ran the project test suite with `pytest` and the suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab9c93974832082a438d1ff1b4585)